### PR TITLE
Fix tracker lists index desync

### DIFF
--- a/mod/InGameTracker/TrackerInventoryMode.cs
+++ b/mod/InGameTracker/TrackerInventoryMode.cs
@@ -15,7 +15,6 @@ namespace ArchipelagoRandomizer.InGameTracker
         public GameObject RootObject;
         public TrackerManager Tracker;
 
-        private int selectedIndex;
         private Image Icon => Wrapper.GetPhoto();
         private Text QuestionMark => Wrapper.GetQuestionMark();
 
@@ -32,10 +31,9 @@ namespace ArchipelagoRandomizer.InGameTracker
             Wrapper.SetItems(Tracker.InventoryItems);
             Wrapper.SetSelectedIndex(0);
             Wrapper.UpdateList();
-            selectedIndex = 0;
             RootObject.name = "ArchipelagoInventoryMode";
 
-            SelectItem(0);
+            SelectItem(Wrapper.GetSelectedIndex());
         }
 
         // Runs when the mode is closed
@@ -68,12 +66,7 @@ namespace ArchipelagoRandomizer.InGameTracker
 
             if (changeIndex != 0)
             {
-                selectedIndex += changeIndex;
-
-                if (selectedIndex < 0) selectedIndex = Tracker.InventoryItems.Count - 1;
-                if (selectedIndex >= Tracker.InventoryItems.Count) selectedIndex = 0;
-
-                SelectItem(selectedIndex);
+                SelectItem(Wrapper.GetSelectedIndex());
             }
         }
 

--- a/mod/InGameTracker/TrackerLocationChecklistMode.cs
+++ b/mod/InGameTracker/TrackerLocationChecklistMode.cs
@@ -21,8 +21,6 @@ namespace ArchipelagoRandomizer.InGameTracker
 
         public bool IsInChecklist = false;
 
-        private int checklistSelectedIndex;
-        private int selectionSelectedIndex;
         private GameObject shipLogPanRoot;
         Dictionary<string, TrackerChecklistData> checklist;
 
@@ -122,11 +120,7 @@ namespace ArchipelagoRandomizer.InGameTracker
                 changeIndex = ChecklistWrapper.UpdateList();
                 if (changeIndex != 0)
                 {
-                    checklistSelectedIndex += changeIndex;
-
-                    if (checklistSelectedIndex < 0) checklistSelectedIndex = Tracker.CurrentLocations.Count - 1;
-                    if (checklistSelectedIndex >= Tracker.CurrentLocations.Count) checklistSelectedIndex = 0;
-                    SelectChecklistItem(checklistSelectedIndex);
+                    SelectChecklistItem(ChecklistWrapper.GetSelectedIndex());
                 }
                 if (OWInput.IsNewlyPressed(InputLibrary.cancel))
                 {
@@ -140,15 +134,11 @@ namespace ArchipelagoRandomizer.InGameTracker
 
                 if (changeIndex != 0)
                 {
-                    selectionSelectedIndex += changeIndex;
-
-                    if (selectionSelectedIndex < 0) selectionSelectedIndex = optionsList.Count - 1;
-                    if (selectionSelectedIndex >= optionsList.Count) selectionSelectedIndex = 0;
-                    SelectSelectionItem(selectionSelectedIndex);
+                    SelectSelectionItem(SelectionWrapper.GetSelectedIndex());
                 }
                 if (OWInput.IsNewlyPressed(InputLibrary.menuConfirm))
                 {
-                    OpenChecklistPage(selectionSelectedIndex);
+                    OpenChecklistPage(SelectionWrapper.GetSelectedIndex());
                 }
             }
         }
@@ -225,7 +215,6 @@ namespace ArchipelagoRandomizer.InGameTracker
             ChecklistWrapper.SetItems(Tracker.CurrentLocations);
             ChecklistWrapper.SetSelectedIndex(0);
             ChecklistWrapper.UpdateList();
-            checklistSelectedIndex = 0;
             ChecklistRootObject.name = "ArchipelagoChecklistMode";
 
             IsInChecklist = true;
@@ -384,9 +373,8 @@ namespace ArchipelagoRandomizer.InGameTracker
             SelectionWrapper.SetSelectedIndex(0);
             SelectionWrapper.UpdateList();
             SelectionRootObject.name = "ArchipelagoSelectorMode";
-            selectionSelectedIndex = 0;
             IsInChecklist = false;
-            SelectSelectionItem(0);
+            SelectSelectionItem(SelectionWrapper.GetSelectedIndex());
         }
 
         private void SelectSelectionItem(int index)


### PR DESCRIPTION
This fixes an issue where the lists in the tracker Ship Log modes are shifted respect the info displayed (photo, description field or the custom UI in the tracker).

One way to reproduce this error is to go to the mode selector and position the list cursor above the AP Checklist:
![example](https://github.com/Ixrec/OuterWildsArchipelagoRandomizer/assets/22490080/89eaeb65-3259-4af2-8a95-8a1ab3539617)

Then press down and "E" at the same time, entering the mode with desync issue:
![example](https://github.com/Ixrec/OuterWildsArchipelagoRandomizer/assets/22490080/4bf4549f-bda2-472d-a15d-cbf97df879cc)

This happens because the custom modes mantain the index of the lists in an field (`TrackerInventoryMode`'s `selectedIndex` and `TrackerLocationChecklistMode`'s  `checklistSelectedIndex` and `selectionSelectedIndex`), that are used to know what information to show, but these indexes could differ from the list's actual indexes. 
This difference comes from this (and similar in the other 2 lists):
```cs
Wrapper.SetSelectedIndex(0);
Wrapper.UpdateList();
selectedIndex = 0;
```

The first line sets the (real) index of the list to `0`, but then `UpdateList`  takes the input of the user, and if they presses up/down at the same frame when this code runs, it would change the index of the list (to `1`  for example, if they pressed down). And then the mode sets `selectedIndex` to `0`, which in that case would be wrong, explaining the shift.

One solution could be calling the `SetSelectedIndex` after the `UpdateList` instead of before (then we would know for sure that it would be `0`).
But there's also the `UpdateListUI` API method that just updates the list UI without changing the index because of user index, so another solution could be just replacing these `UpdateList` calls to `UpdateListUI`.

However, there isn't even a need to keep track of the indexes ourselves, the CSLM API's also provedes the `GetSelectedIndex` method, so my solution was just deleting those fields and get the indexes when needed with that method, preventing any possiblity of shifting the list with the displayed info.
