### PR TITLE
Tracker layout fix

### DIFF
--- a/mod/InGameTracker/LocationInfos/GD.jsonc
+++ b/mod/InGameTracker/LocationInfos/GD.jsonc
@@ -77,7 +77,7 @@
     },
     {
         "locationModID": "GD_GABBRO_TANK",
-        "description": "It might be good to refill your fuel tank after you talk to your time buddy. You'll need to make a small detour to find his camp.",
+        "description": "It might be good to refill your fuel tank after you talk to your time buddy. You'll need to make a small detour to find their camp.",
         "thumbnail": "GD_GABBRO_ISLAND"
     }
 ]

--- a/mod/InGameTracker/LocationInfos/TH.jsonc
+++ b/mod/InGameTracker/LocationInfos/TH.jsonc
@@ -70,6 +70,11 @@
         "thumbnail": "TM_ESKER"
     },
     {
+        "locationModID": "AR_ESKER_TANK",
+        "description": "The Attlerock outpost was originally used for Travellers to refuel before they'd travel to further reaches of the Outer Wilds. While such a stop is no longer needed, how about you try restocking there for nostalgia's sake?",
+        "thumbnail": "TM_ESKER"
+    },
+    {
         "locationModID": "AR_ESL",
         "description": "The Nomai's first attempt to locate the Eye of the Universe can be found on the Attlerock. They've written about their findings on a wall.",
         "thumbnail": "TM_EYE_LOCATOR"

--- a/mod/InGameTracker/TrackerLocationChecklistMode.cs
+++ b/mod/InGameTracker/TrackerLocationChecklistMode.cs
@@ -235,7 +235,7 @@ namespace ArchipelagoRandomizer.InGameTracker
             {
                 ChecklistWrapper.DescriptionFieldGetNextItem().DisplayText(locData.hintText);
             }
-            ChecklistWrapper.DescriptionFieldGetNextItem().DisplayText("Full name: " + data.name);
+            ChecklistWrapper.DescriptionFieldGetNextItem().DisplayText("<color=#8DCEFF>Full name: " + data.name + "</color>");
             ChecklistWrapper.DescriptionFieldGetNextItem().DisplayText(Tracker.logic.GetLocationLogicString(data));
             ChecklistWrapper.DescriptionFieldGetNextItem().DisplayText(Tracker.logic.GetRegionLogicString(data.region));
         }
@@ -426,8 +426,8 @@ namespace ArchipelagoRandomizer.InGameTracker
                 selectorMaterial.SetFloat("_PercentAccessible", accessiblePercentage);
                 selectorMaterial.SetFloat("_PercentComplete", checkedPercentage);
                 bodyName.text = CategoryToName(category);
-                locationsChecked.text = $"Locations Checked: {checkedLocs}/{allLocs}";
-                locationsAccessible.text = $"Locations Accessible: {(int)(accessLocs - checkedLocs)}/{allLocs - checkedLocs}";
+                locationsChecked.text = $"{checkedLocs} Checked / {allLocs} Total";
+                locationsAccessible.text = $"{(int)(accessLocs - checkedLocs)} Accessible / {allLocs - checkedLocs} Remaining";
                 string exploreText;
                 if (checkedLocs >= allLocs) exploreText = $"<color={completed}>There's no more to explore here.\nGood job!</color>";
                 else if (checkedLocs < accessLocs) exploreText = $"<color={so5}>There's more to explore here.</color>";

--- a/mod/InGameTracker/TrackerLogic.cs
+++ b/mod/InGameTracker/TrackerLogic.cs
@@ -341,16 +341,16 @@ namespace ArchipelagoRandomizer.InGameTracker
         /// <returns></returns>
         public string GetLocationLogicString(TrackerLocationData data)
         {
-            string logicString = "Location Logic: ";
+            string logicString = "<color=grey>Location Logic: ";
             foreach (TrackerRequirement req in data.requires)
             {
                 if (!string.IsNullOrEmpty(req.item))
                 {
-                    if (!logicString.EndsWith(": ")) logicString += " AND ";
+                    if (!logicString.EndsWith(": ")) logicString += " <color=lime>AND</color> ";
                     logicString += $"(item: {req.item})";
                 }
             }
-
+            logicString += "</color>";
             return logicString;
         }
 
@@ -362,21 +362,21 @@ namespace ArchipelagoRandomizer.InGameTracker
         public string GetRegionLogicString(string region)
         {
             TrackerRegionData data = TrackerRegions[region];
-            string logicString = "Regional Logic: ";
+            string logicString = "<color=grey>Regional Logic: ";
             if (data.fromConnections != null && data.fromConnections.Count > 0)
             {
                 foreach (TrackerConnectionData connection in data.fromConnections)
                 {
-                    if (!logicString.EndsWith("(") && !logicString.EndsWith(": ")) logicString += " OR ";
+                    if (!logicString.EndsWith("(") && !logicString.EndsWith(": ")) logicString += " <color=orange>OR</color> ";
                     logicString += $"(Can Access: {connection.from} ";
                     if (connection.requires != null && connection.requires.Count > 0)
                     {
-                        logicString += "AND (";
+                        logicString += "<color=lime>AND</color> (";
                         foreach (TrackerRequirement req in connection.requires)
                         {
                             if (!string.IsNullOrEmpty(req.item))
                             {
-                                if (!logicString.EndsWith("(")) logicString += " AND ";
+                                if (!logicString.EndsWith("(")) logicString += "<color=lime>AND</color> ";
                                 logicString += $"Item: {req.item}";
                             }
                             if (req.anyOf != null && req.anyOf.Count > 0)
@@ -384,7 +384,7 @@ namespace ArchipelagoRandomizer.InGameTracker
                                 logicString = "(";
                                 foreach (var con in req.anyOf)
                                 {
-                                    if (!logicString.EndsWith("(")) logicString += " OR ";
+                                    if (!logicString.EndsWith("(")) logicString += " <color=orange>OR</color> ";
                                     logicString += $"Item: {con.item}";
                                     // not going to bother with nested any ofs for now, not sure if those will ever have a reason to be used.
                                 }
@@ -396,6 +396,7 @@ namespace ArchipelagoRandomizer.InGameTracker
                     logicString += ")";
                 }
             }
+            logicString += "</color>";
             return logicString;
         }
 


### PR DESCRIPTION
* Location quantity on the main tracker menu now has each number labeled
* The descriptions of locations are now easier to read thanks to colored text
* Added a missing location to the Timber Hearth tracker (Esker's tank)
* Fixed an incorrect pronoun in the GD location hint file