### PR TITLE
Locations match contents: Nomai Text Arcs

### DIFF
--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -47,6 +47,7 @@ public class APRandomizer : ModBehaviour
     public static IModConsole OWMLModConsole { get => Instance.ModHelper.Console; }
     public static ArchConsoleManager InGameAPConsole;
     public static TrackerManager Tracker;
+    public static Scouter LocationScouter;
 
     /// <summary>
     /// Runs whenever a new session is created
@@ -320,6 +321,8 @@ public class APRandomizer : ModBehaviour
         InGameAPConsole = gameObject.AddComponent<ArchConsoleManager>();
 
         Tracker = gameObject.AddComponent<TrackerManager>();
+
+        LocationScouter = new();
 
         LoadManager.OnCompleteSceneLoad += (scene, loadScene) =>
         {

--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -61,6 +61,7 @@ public class APRandomizer : ModBehaviour
     public static event Action<ArchipelagoSession, bool> OnSessionClosed;
 
     public static bool AutoNomaiText = false;
+    public static bool CheckTypeMatchContents = true;
 
     public static bool DisableConsole = false;
     public static bool DisableInGameLocationSending = false;
@@ -338,6 +339,7 @@ public class APRandomizer : ModBehaviour
         LoadManager.OnStartSceneLoad += (scene, loadScene) =>
         {
             NomaiTextQoL.AutoNomaiText = AutoNomaiText;
+            NomaiTextQoL.ColorNomaiText = CheckTypeMatchContents;
         };
 
         SetupSaveData();
@@ -560,6 +562,7 @@ public class APRandomizer : ModBehaviour
     {
         // Configure() is called early and often, including before we create the Console
         AutoNomaiText = config.GetSettingsValue<bool>("Auto Expand Nomai Text");
+        CheckTypeMatchContents = config.GetSettingsValue<bool>("Location Appearance Matches Contents");
         NomaiTextQoL.TranslateTime = config.GetSettingsValue<bool>("Instant Translator") ? 0f : 0.2f;
 
         DisableConsole = config.GetSettingsValue<bool>("[DEBUG] Disable In-Game Console");

--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -61,7 +61,7 @@ public class APRandomizer : ModBehaviour
     public static event Action<ArchipelagoSession, bool> OnSessionClosed;
 
     public static bool AutoNomaiText = false;
-    public static bool CheckTypeMatchContents = true;
+    public static bool ColorNomaiText = true;
 
     public static bool DisableConsole = false;
     public static bool DisableInGameLocationSending = false;
@@ -339,7 +339,7 @@ public class APRandomizer : ModBehaviour
         LoadManager.OnStartSceneLoad += (scene, loadScene) =>
         {
             NomaiTextQoL.AutoNomaiText = AutoNomaiText;
-            NomaiTextQoL.ColorNomaiText = CheckTypeMatchContents;
+            NomaiTextQoL.ColorNomaiText = ColorNomaiText;
         };
 
         SetupSaveData();
@@ -562,7 +562,7 @@ public class APRandomizer : ModBehaviour
     {
         // Configure() is called early and often, including before we create the Console
         AutoNomaiText = config.GetSettingsValue<bool>("Auto Expand Nomai Text");
-        CheckTypeMatchContents = config.GetSettingsValue<bool>("Location Appearance Matches Contents");
+        ColorNomaiText = config.GetSettingsValue<bool>("LocationAppearanceMatchesContents");
         NomaiTextQoL.TranslateTime = config.GetSettingsValue<bool>("Instant Translator") ? 0f : 0.2f;
 
         DisableConsole = config.GetSettingsValue<bool>("[DEBUG] Disable In-Game Console");

--- a/mod/ArchipelagoItem.cs
+++ b/mod/ArchipelagoItem.cs
@@ -1,0 +1,22 @@
+﻿using Archipelago.MultiClient.Net.Enums;
+
+namespace ArchipelagoRandomizer
+{
+    /// <summary>
+    /// Defines the information related to an item
+    /// </summary>
+    public struct ArchipelagoItem
+    {
+        // more or less copied from the Tunic AP
+        public string ItemName;
+        public int PlayerSlot;
+        public ItemFlags Flags;
+
+        public ArchipelagoItem(string itemName, int playerSlot, ItemFlags flags)
+        {
+            ItemName = itemName;
+            PlayerSlot = playerSlot;
+            Flags = flags;
+        }
+    }
+}

--- a/mod/CheckHintData.cs
+++ b/mod/CheckHintData.cs
@@ -71,6 +71,7 @@ namespace ArchipelagoRandomizer
         public void DetermineImportance(Location loc)
         {
             locations.Add(loc);
+            if (APRandomizer.APSession.Locations.AllLocationsChecked.Contains(LocationNames.locationToArchipelagoId[loc])) HasBeenFound = true;
 
             switch (Scouter.ScoutedLocations[loc].Flags)
             {

--- a/mod/CheckHintData.cs
+++ b/mod/CheckHintData.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+using Archipelago.MultiClient.Net.Enums;
+
+namespace ArchipelagoRandomizer
+{
+    public class CheckHintData : MonoBehaviour
+    {
+        // Since arcs have no idea which logs they're connected to,
+        // we record them and their other location checks here in a list
+        // so we can easily see them in Unity Explorer
+        // Currently unused in any code but may use it later
+        public List<Location> locations = new List<Location>();
+        public CheckImportance Importance = CheckImportance.Junk;
+        public bool HasBeenFound = false;
+
+        public static readonly Color JunkColor = new(0.5f, 1.5f, 1.5f, 1);
+        public static readonly Color UsefulColor = new(0.5f, 1.8f, 0.5f, 1);
+        public static readonly Color ProgressionColor = new(1.5f, 0.5f, 1.5f, 1);
+        public static readonly Color FoundColor = new(1.2f, 1.2f, 1.2f, 1);
+
+        public static Material ChildTextMat
+        {
+            get
+            {
+                if (childTextMat == null)
+                    childTextMat = Locator.GetAstroObject(AstroObject.Name.CaveTwin).transform
+                        .Find("Sector_CaveTwin/Sector_SouthHemisphere/Sector_SouthUnderground/Sector_City/Interactables_City/Arc_CT_City_KidDirectionToFossil_1/Arc 1")
+                        .GetComponent<Renderer>().material;
+                return childTextMat;
+            }
+        }
+
+        private static Material childTextMat;
+
+        public Color NomaiWallColor()
+        {
+            if (HasBeenFound) return FoundColor;
+            switch (Importance)
+            {
+                case CheckImportance.Junk:
+                    return JunkColor;
+                case CheckImportance.Useful:
+                    return UsefulColor;
+                case CheckImportance.Progression:
+                    return ProgressionColor;
+                default:
+                    {
+                        int rnd = Random.Range(0, 3);
+                        switch (rnd)
+                        {
+                            case 0:
+                                return JunkColor;
+                            case 1:
+                                return UsefulColor;
+                            default:
+                                return ProgressionColor;
+                        }    
+                    }
+            }
+        }
+
+        public void SetImportance(CheckImportance importance)
+        {
+            if ((int)Importance < (int)importance)
+            {
+                Importance = importance;
+            }
+        }
+
+        public void DetermineImportance(Location loc)
+        {
+            locations.Add(loc);
+
+            switch (Scouter.ScoutedLocations[loc].Flags)
+            {
+                case ItemFlags.None:
+                    SetImportance(CheckImportance.Junk);
+                    break;
+                case ItemFlags.NeverExclude:
+                    SetImportance(CheckImportance.Useful);
+                    break;
+                case ItemFlags.Advancement:
+                    SetImportance(CheckImportance.Progression);
+                    break;
+                case ItemFlags.Trap:
+                    SetImportance(CheckImportance.Trap);
+                    GetComponent<Renderer>().material = ChildTextMat; // TODO make this depend on whether it's already a child arc
+                    break;
+            }
+        }
+
+        private void Awake()
+        {
+            APRandomizer.OWMLModConsole.WriteLine($"I've been added to {transform.parent.name}/{gameObject.name}!");
+        }
+    }
+    public enum CheckImportance
+    {
+        Trap = 0,
+        Junk = 1,
+        Useful = 2,
+        Progression = 3
+    }
+}

--- a/mod/CheckHintData.cs
+++ b/mod/CheckHintData.cs
@@ -10,9 +10,10 @@ namespace ArchipelagoRandomizer
         // we record them and their other location checks here in a list
         // so we can easily see them in Unity Explorer
         // Currently unused in any code but may use it later
-        public List<Location> locations = new List<Location>();
+        public List<Location> Locations = new List<Location>();
         public CheckImportance Importance = CheckImportance.Junk;
         public bool HasBeenFound = false;
+        public bool IsChildText = false;
 
         public static readonly Color JunkColor = new(0.5f, 1.5f, 1.5f, 1);
         public static readonly Color UsefulColor = new(0.5f, 1.8f, 0.5f, 1);
@@ -31,7 +32,22 @@ namespace ArchipelagoRandomizer
             }
         }
 
+        public static Material NormalTextMat
+        {
+            get
+            {
+                if (normalTextMat == null)
+                    normalTextMat = Locator.GetAstroObject(AstroObject.Name.TimberHearth).transform
+                        .Find("Sector_TH/Sector_Village/Sector_Observatory/Interactables_Observatory/NomaiEyeExhibit/NomaiEyePivot/Arc_TH_Museum_EyeSymbol/Arc 1")
+                        .GetComponent<Renderer>().material;
+                return normalTextMat;
+            }
+        }
+
         private static Material childTextMat;
+        private static Material normalTextMat;
+
+        private Renderer rend;
 
         public Color NomaiWallColor()
         {
@@ -70,8 +86,15 @@ namespace ArchipelagoRandomizer
 
         public void DetermineImportance(Location loc)
         {
-            locations.Add(loc);
+            rend = GetComponent<Renderer>();
+
+            Locations.Add(loc);
             if (APRandomizer.APSession.Locations.AllLocationsChecked.Contains(LocationNames.locationToArchipelagoId[loc])) HasBeenFound = true;
+
+            if (Importance != CheckImportance.Trap)
+            {
+                if (rend.material.name.Contains("TextChild")) IsChildText = true;
+            }
 
             switch (Scouter.ScoutedLocations[loc].Flags)
             {
@@ -86,14 +109,9 @@ namespace ArchipelagoRandomizer
                     break;
                 case ItemFlags.Trap:
                     SetImportance(CheckImportance.Trap);
-                    GetComponent<Renderer>().material = ChildTextMat; // TODO make this depend on whether it's already a child arc
+                    rend.material = IsChildText ? NormalTextMat : ChildTextMat;
                     break;
             }
-        }
-
-        private void Awake()
-        {
-            APRandomizer.OWMLModConsole.WriteLine($"I've been added to {transform.parent.name}/{gameObject.name}!");
         }
     }
     public enum CheckImportance

--- a/mod/CheckHintData.cs
+++ b/mod/CheckHintData.cs
@@ -11,9 +11,10 @@ namespace ArchipelagoRandomizer
         // so we can easily see them in Unity Explorer
         // Currently unused in any code but may use it later
         public List<Location> Locations = new List<Location>();
-        public CheckImportance Importance = CheckImportance.Junk;
+        public CheckImportance Importance = CheckImportance.Filler;
         public bool HasBeenFound = false;
-        public bool IsChildText = false;
+
+        private bool IsChildText = false;
 
         public static readonly Color JunkColor = new(0.5f, 1.5f, 1.5f, 1);
         public static readonly Color UsefulColor = new(0.5f, 1.8f, 0.5f, 1);
@@ -54,7 +55,7 @@ namespace ArchipelagoRandomizer
             if (HasBeenFound) return FoundColor;
             switch (Importance)
             {
-                case CheckImportance.Junk:
+                case CheckImportance.Filler:
                     return JunkColor;
                 case CheckImportance.Useful:
                     return UsefulColor;
@@ -99,7 +100,7 @@ namespace ArchipelagoRandomizer
             switch (Scouter.ScoutedLocations[loc].Flags)
             {
                 case ItemFlags.None:
-                    SetImportance(CheckImportance.Junk);
+                    SetImportance(CheckImportance.Filler);
                     break;
                 case ItemFlags.NeverExclude:
                     SetImportance(CheckImportance.Useful);
@@ -117,7 +118,7 @@ namespace ArchipelagoRandomizer
     public enum CheckImportance
     {
         Trap = 0,
-        Junk = 1,
+        Filler = 1,
         Useful = 2,
         Progression = 3
     }

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -9,7 +9,7 @@ namespace ArchipelagoRandomizer;
 internal class LocationTriggers
 {
     // Only for default locations. Logsanity locations have the log fact in their id so they don't need an additional hardcoded map.
-    static Dictionary<string, Location> logFactToDefaultLocation = new Dictionary<string, Location>{
+    public static Dictionary<string, Location> logFactToDefaultLocation = new Dictionary<string, Location>{
         { "S_SUNSTATION_X2", Location.SS },
 
         { "CT_HIGH_ENERGY_LAB_X3", Location.ET_HEL },

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -73,6 +73,14 @@ internal class LocationTriggers
         { "DB_VESSEL_X1", Location.DB_VESSEL },
     };
 
+    // manual scrolls
+    public static Dictionary<string, Location> ManualScrollLocations = new()
+        {
+            { "BH_City_School_BigBangLesson", Location.BH_SOLANUM_REPORT },
+            { "TT_Tower_CT", Location.AT_HGT_TOWERS },
+            { "TT_Tower_BH_1", Location.AT_BH_TOWER }
+        };
+
     // no longer in use, keeping as notes for when we edit flavor text to justify some items' existence
     /*static Dictionary<Location, Item> locationToVanillaItem = new Dictionary<Location, Item> {
         { Location.ET_FOSSIL, Item.SilentRunning },
@@ -281,11 +289,9 @@ internal class LocationTriggers
 
         var textAssetName = __instance._nomaiTextAsset?.name ?? "(No text asset, likely generated in code?)";
 
-        switch (textAssetName)
+        if (ManualScrollLocations.ContainsKey(textAssetName))
         {
-            case "BH_City_School_BigBangLesson": CheckLocation(Location.BH_SOLANUM_REPORT); break;
-            case "TT_Tower_CT": CheckLocation(Location.AT_HGT_TOWERS); break;
-            case "TT_Tower_BH_1": CheckLocation(Location.AT_BH_TOWER); break;
+            CheckLocation(ManualScrollLocations[textAssetName]);
         }
     }
 

--- a/mod/NomaiTextQoL.cs
+++ b/mod/NomaiTextQoL.cs
@@ -90,6 +90,19 @@ namespace ArchipelagoRandomizer
             }
         }
 
+        [HarmonyPrefix, HarmonyPatch(typeof(NomaiTextLine), nameof(NomaiTextLine.DetermineTextLineColor))]
+        public static bool NomaiTextLine_DetermineTextLineColor_Prefix(NomaiText __instance, ref NomaiTextLine.VisualState state, ref Color __result)
+        {
+            CheckHintData data = __instance.GetComponent<CheckHintData>();
+            if (!ColorNomaiText || data == null || state != NomaiTextLine.VisualState.UNREAD || data.locations.Count == 0)
+            {
+                return true;
+            }
+
+            __result = data.NomaiWallColor();
+            return false;
+        }
+
         // fixes for the text not becoming properly grey when read
         [HarmonyReversePatch, HarmonyPatch(typeof(NomaiText), nameof(NomaiText.SetAsTranslated))]
         public static void base_SetAsTranslated(NomaiText instance, int id) { }

--- a/mod/NomaiTextQoL.cs
+++ b/mod/NomaiTextQoL.cs
@@ -1,4 +1,7 @@
 ﻿using HarmonyLib;
+using System.Linq;
+using System;
+using UnityEngine;
 
 namespace ArchipelagoRandomizer
 {
@@ -6,26 +9,84 @@ namespace ArchipelagoRandomizer
     internal class NomaiTextQoL
     {
         public static bool AutoNomaiText;
+        public static bool ColorNomaiText = true;
         public static float TranslateTime = 0.2f;
 
         // Auto-expand all Nomai text in the game as a Quality of Life feature
         [HarmonyPostfix, HarmonyPatch(typeof(NomaiWallText), nameof(NomaiWallText.LateInitialize))]
         public static void NomaiWallText_LateInitialize_Postfix(NomaiWallText __instance)
         {
-            if (!AutoNomaiText) return;
-            foreach (NomaiTextLine child in __instance.GetComponentsInChildren<NomaiTextLine>())
+            if (ColorNomaiText)
             {
-                child._state = NomaiTextLine.VisualState.UNREAD;
+                // we can't directly get the logs connected to arcs,
+                // so we have to do this roundabout system (also used in base game)
+                // to iterate through a bunch of conditions, and find the arc that matches the condition of the log
+                for (int i = 0; i < __instance._listDBConditions.Count; i++)
+                {
+                    var nomaiTextData = __instance._listDBConditions[i];
+                    if (string.IsNullOrEmpty(nomaiTextData.DatabaseID)) continue;
+                    //APRandomizer.OWMLModConsole.WriteLine($"{__instance.gameObject.name} log found: {nomaiTextData.DatabaseID}");
+                    for (int j = 0; j < nomaiTextData.ConditionBlock.Length; j++)
+                    {
+                        for (int k = 0; k < nomaiTextData.ConditionBlock[j].Length; k++)
+                        {
+                            int key = nomaiTextData.ConditionBlock[j][k];
+                            // if this succeeds we've found an arc that matches the conditions, and thus we can find which log is attached
+                            // I don't understand it either, blame Mobius making this system far more complicated than it needed to be
+                            if (__instance._dictNomaiTextData.ContainsKey(key))
+                            {
+                                var textLine = __instance._textLines.First(x => x.GetEntryID() == key);
+                                APRandomizer.OWMLModConsole.WriteLine($"{__instance.gameObject.name} changing color for {textLine.gameObject.name}", OWML.Common.MessageType.Success);
+
+                                CheckHintData hintData = textLine.gameObject.GetAddComponent<CheckHintData>();
+
+                                // Manual locations
+                                string textAssetName = __instance._nomaiTextAsset?.name ?? "(No text asset, likely generated in code?)";
+
+                                switch (textAssetName)
+                                {
+                                    case "BH_City_School_BigBangLesson": hintData.DetermineImportance(Location.BH_SOLANUM_REPORT); break;
+                                    case "TT_Tower_CT": hintData.DetermineImportance(Location.AT_HGT_TOWERS); break;
+                                    case "TT_Tower_BH_1": hintData.DetermineImportance(Location.AT_BH_TOWER); break;
+                                }
+
+                                // DatabaseID is the ship log name
+                                string log = nomaiTextData.DatabaseID;
+
+                                // Check for Location Triggers
+                                if (LocationTriggers.logFactToDefaultLocation.ContainsKey(log))
+                                {
+                                    hintData.DetermineImportance(LocationTriggers.logFactToDefaultLocation[log]);
+                                }
+
+                                // Check for Logsanity checks
+                                bool isALog = Enum.TryParse<Location>("SLF__" + nomaiTextData.DatabaseID, out Location loc);
+                                if (isALog && APRandomizer.SlotData.ContainsKey("logsanity") && (long)APRandomizer.SlotData["logsanity"] != 0)
+                                {
+                                    hintData.DetermineImportance(loc);
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
-            // Ignore scrolls if they aren't socketed
-            bool isScroll = __instance.transform.GetComponentInParent<ScrollItem>() != null;
-            bool isSocketed = __instance.transform.GetComponentInParent<ScrollSocket>() != null;
-            bool isAProjectionWall = __instance.transform.GetComponentInParent<NomaiSharedWhiteboard>() != null;
-
-            if ((!isScroll || isSocketed) && !isAProjectionWall)
+            if (AutoNomaiText)
             {
-                __instance.ShowImmediate();
+                foreach (NomaiTextLine child in __instance.GetComponentsInChildren<NomaiTextLine>())
+                {
+                    child._state = NomaiTextLine.VisualState.UNREAD;
+                }
+
+                // Ignore scrolls if they aren't socketed
+                bool isScroll = __instance.transform.GetComponentInParent<ScrollItem>() != null;
+                bool isSocketed = __instance.transform.GetComponentInParent<ScrollSocket>() != null;
+                bool isAProjectionWall = __instance.transform.GetComponentInParent<NomaiSharedWhiteboard>() != null;
+
+                if ((!isScroll || isSocketed) && !isAProjectionWall)
+                {
+                    __instance.ShowImmediate();
+                }
             }
         }
 

--- a/mod/NomaiTextQoL.cs
+++ b/mod/NomaiTextQoL.cs
@@ -13,12 +13,7 @@ namespace ArchipelagoRandomizer
         public static bool ColorNomaiText = true;
         public static float TranslateTime = 0.2f;
 
-        public static Dictionary<string, Location> ManualScrollLocations = new()
-        {
-            { "Arc_BH_City_School_BigBangLesson", Location.BH_SOLANUM_REPORT },
-            { "Arc_TT_Tower_CT", Location.AT_HGT_TOWERS },
-            { "Arc_TT_Tower_BH_1", Location.AT_BH_TOWER }
-        };
+        
 
         // Auto-expand all Nomai text in the game as a Quality of Life feature
         [HarmonyPostfix, HarmonyPatch(typeof(NomaiWallText), nameof(NomaiWallText.LateInitialize))]
@@ -91,12 +86,12 @@ namespace ArchipelagoRandomizer
                 }
 
                 // For manually marked scrolls
-                if (ManualScrollLocations.ContainsKey(__instance.gameObject.name))
+                if (LocationTriggers.ManualScrollLocations.ContainsKey("Arc_" + __instance.gameObject.name))
                 {
                     NomaiTextLine textLine = __instance.transform.GetComponentInChildren<NomaiTextLine>();
                     CheckHintData hintData = textLine.gameObject.GetAddComponent<CheckHintData>();
 
-                    hintData.DetermineImportance(ManualScrollLocations[__instance.gameObject.name]);
+                    hintData.DetermineImportance(LocationTriggers.ManualScrollLocations["Arc_" + __instance.gameObject.name]);
                 }
             }
 
@@ -140,7 +135,7 @@ namespace ArchipelagoRandomizer
         public static bool NomaiWallText_SetAsTranslated_Prefix(NomaiWallText __instance, ref int id)
         {
             if (!AutoNomaiText) return true;
-            if (ManualScrollLocations.ContainsKey(__instance.gameObject.name)) return true;
+            if (LocationTriggers.ManualScrollLocations.ContainsKey("Arc_" + __instance.gameObject.name)) return true;
             // This code is copied from the base game and overrides the original method
             base_SetAsTranslated(__instance, id);
             bool revealedChildren = false;

--- a/mod/NomaiTextQoL.cs
+++ b/mod/NomaiTextQoL.cs
@@ -68,7 +68,6 @@ namespace ArchipelagoRandomizer
                             if (__instance._dictNomaiTextData.ContainsKey(key))
                             {
                                 var textLine = __instance._textLines.First(x => x.GetEntryID() == key);
-                                APRandomizer.OWMLModConsole.WriteLine($"{__instance.gameObject.name} changing color for {textLine.gameObject.name}", OWML.Common.MessageType.Success);
 
                                 CheckHintData hintData = textLine.gameObject.GetAddComponent<CheckHintData>();
 
@@ -125,7 +124,7 @@ namespace ArchipelagoRandomizer
         public static bool NomaiTextLine_DetermineTextLineColor_Prefix(NomaiText __instance, ref NomaiTextLine.VisualState state, ref Color __result)
         {
             CheckHintData data = __instance.GetComponent<CheckHintData>();
-            if (!ColorNomaiText || data == null || state != NomaiTextLine.VisualState.UNREAD || data.locations.Count == 0)
+            if (!ColorNomaiText || data == null || state != NomaiTextLine.VisualState.UNREAD || data.Locations.Count == 0)
             {
                 return true;
             }

--- a/mod/NomaiTextQoL.cs
+++ b/mod/NomaiTextQoL.cs
@@ -86,12 +86,13 @@ namespace ArchipelagoRandomizer
                 }
 
                 // For manually marked scrolls
-                if (LocationTriggers.ManualScrollLocations.ContainsKey("Arc_" + __instance.gameObject.name))
+                string name = __instance.gameObject.name.Replace("Arc_", "");
+                if (LocationTriggers.ManualScrollLocations.ContainsKey(name))
                 {
                     NomaiTextLine textLine = __instance.transform.GetComponentInChildren<NomaiTextLine>();
                     CheckHintData hintData = textLine.gameObject.GetAddComponent<CheckHintData>();
 
-                    hintData.DetermineImportance(LocationTriggers.ManualScrollLocations["Arc_" + __instance.gameObject.name]);
+                    hintData.DetermineImportance(LocationTriggers.ManualScrollLocations[name]);
                 }
             }
 
@@ -135,7 +136,7 @@ namespace ArchipelagoRandomizer
         public static bool NomaiWallText_SetAsTranslated_Prefix(NomaiWallText __instance, ref int id)
         {
             if (!AutoNomaiText) return true;
-            if (LocationTriggers.ManualScrollLocations.ContainsKey("Arc_" + __instance.gameObject.name)) return true;
+            if (LocationTriggers.ManualScrollLocations.ContainsKey(__instance.gameObject.name.Replace("Arc_", ""))) return true;
             // This code is copied from the base game and overrides the original method
             base_SetAsTranslated(__instance, id);
             bool revealedChildren = false;

--- a/mod/NomaiTextQoL.cs
+++ b/mod/NomaiTextQoL.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System.Linq;
 using System;
 using UnityEngine;
@@ -57,7 +57,6 @@ namespace ArchipelagoRandomizer
                         continue;
                     }
 
-                    //APRandomizer.OWMLModConsole.WriteLine($"{__instance.gameObject.name} log found: {nomaiTextData.DatabaseID}");
                     for (int j = 0; j < nomaiTextData.ConditionBlock.Length; j++)
                     {
                         for (int k = 0; k < nomaiTextData.ConditionBlock[j].Length; k++)

--- a/mod/Scouter.cs
+++ b/mod/Scouter.cs
@@ -22,7 +22,6 @@ namespace ArchipelagoRandomizer
 
         public void ScoutAllLocations(ArchipelagoSession session)
         {
-            APRandomizer.OWMLModConsole.WriteLine("Starting scout process...", OWML.Common.MessageType.Message);
             ScoutedLocations = new();
             List<long> locationIDs = new List<long>();
             foreach (Location loc in LocationNames.locationNames.Keys)
@@ -37,16 +36,13 @@ namespace ArchipelagoRandomizer
 
                 locationIDs.Add(LocationNames.locationToArchipelagoId[loc]);
             }
-            APRandomizer.OWMLModConsole.WriteLine($"Compiled list of locations to scout, with {locationIDs.Count} entries...", OWML.Common.MessageType.Message);
 
             // Now we actually scout, code taken and modified from the Tunic randomizer (thanks Silent and Scipio!)
             session.Locations.ScoutLocationsAsync(locationIDs.ToArray()).ContinueWith(locationInfoPacket =>
             {
-                APRandomizer.OWMLModConsole.WriteLine("Scouting items...", OWML.Common.MessageType.Message);
                 foreach (NetworkItem location in locationInfoPacket.Result.Locations)
                 {
                     Location name = LocationNames.archipelagoIdToLocation[location.Location];
-                    APRandomizer.OWMLModConsole.WriteLine($"Adding location {name}");
                     string item = session.Items.GetItemName(location.Item) == null ? "UNKNOWN ITEM" : session.Items.GetItemName(location.Item);
                     ScoutedLocations.Add(name, new(item, location.Player, location.Flags));
                 }

--- a/mod/Scouter.cs
+++ b/mod/Scouter.cs
@@ -22,8 +22,9 @@ namespace ArchipelagoRandomizer
 
         public void ScoutAllLocations(ArchipelagoSession session)
         {
+            APRandomizer.OWMLModConsole.WriteLine("Starting scout process...", OWML.Common.MessageType.Message);
             ScoutedLocations = new();
-            List<long> locations = new List<long>();
+            List<long> locationIDs = new List<long>();
             foreach (Location loc in LocationNames.locationNames.Keys)
             {
                 // annoying exception
@@ -31,18 +32,21 @@ namespace ArchipelagoRandomizer
 
                 // we don't need to scout logsanity locations if logsanity is off
                 bool logsanity = APRandomizer.SlotData.ContainsKey("logsanity") && (long)APRandomizer.SlotData["logsanity"] != 0;
-                APRandomizer.OWMLModConsole.WriteLine($"Got location {loc} and logsanity is {logsanity}");
                 if (!logsanity && LocationNames.IsLogsanityLocation(loc)) continue;
 
 
-                locations.Add(LocationNames.locationToArchipelagoId[loc]);
+                locationIDs.Add(LocationNames.locationToArchipelagoId[loc]);
             }
+            APRandomizer.OWMLModConsole.WriteLine($"Compiled list of locations to scout, with {locationIDs.Count} entries...", OWML.Common.MessageType.Message);
+
             // Now we actually scout, code taken and modified from the Tunic randomizer (thanks Silent and Scipio!)
-            session.Locations.ScoutLocationsAsync(locations.ToArray()).ContinueWith(locationInfoPacket =>
+            session.Locations.ScoutLocationsAsync(locationIDs.ToArray()).ContinueWith(locationInfoPacket =>
             {
+                APRandomizer.OWMLModConsole.WriteLine("Scouting items...", OWML.Common.MessageType.Message);
                 foreach (NetworkItem location in locationInfoPacket.Result.Locations)
                 {
                     Location name = LocationNames.archipelagoIdToLocation[location.Location];
+                    APRandomizer.OWMLModConsole.WriteLine($"Adding location {name}");
                     string item = session.Items.GetItemName(location.Item) == null ? "UNKNOWN ITEM" : session.Items.GetItemName(location.Item);
                     ScoutedLocations.Add(name, new(item, location.Player, location.Flags));
                 }

--- a/mod/Scouter.cs
+++ b/mod/Scouter.cs
@@ -1,0 +1,55 @@
+﻿using Archipelago.MultiClient.Net;
+using Archipelago.MultiClient.Net.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ArchipelagoRandomizer
+{
+    /// <summary>
+    /// Class responsible for scouting locations and returning their values and IDs, for hinting and changing the appearance of checks
+    /// </summary>
+    public class Scouter
+    {
+        public static Dictionary<Location, ArchipelagoItem> ScoutedLocations;
+
+        public Scouter() 
+        {
+            APRandomizer.OnSessionOpened += ScoutAllLocations;
+        }
+
+        public void ScoutAllLocations(ArchipelagoSession session)
+        {
+            ScoutedLocations = new();
+            List<long> locations = new List<long>();
+            foreach (Location loc in LocationNames.locationNames.Keys)
+            {
+                // annoying exception
+                if (loc == Location.SLF__TH_VILLAGE_X3) continue;
+
+                // we don't need to scout logsanity locations if logsanity is off
+                bool logsanity = APRandomizer.SlotData.ContainsKey("logsanity") && (long)APRandomizer.SlotData["logsanity"] != 0;
+                APRandomizer.OWMLModConsole.WriteLine($"Got location {loc} and logsanity is {logsanity}");
+                if (!logsanity && LocationNames.IsLogsanityLocation(loc)) continue;
+
+
+                locations.Add(LocationNames.locationToArchipelagoId[loc]);
+            }
+            // Now we actually scout, code taken and modified from the Tunic randomizer (thanks Silent and Scipio!)
+            session.Locations.ScoutLocationsAsync(locations.ToArray()).ContinueWith(locationInfoPacket =>
+            {
+                foreach (NetworkItem location in locationInfoPacket.Result.Locations)
+                {
+                    Location name = LocationNames.archipelagoIdToLocation[location.Location];
+                    string item = session.Items.GetItemName(location.Item) == null ? "UNKNOWN ITEM" : session.Items.GetItemName(location.Item);
+                    ScoutedLocations.Add(name, new(item, location.Player, location.Flags));
+                }
+
+                APRandomizer.OWMLModConsole.WriteLine("All locations scouted.", OWML.Common.MessageType.Success);
+            }).Wait(TimeSpan.FromSeconds(5));
+
+        }
+    }
+}

--- a/mod/default-config.json
+++ b/mod/default-config.json
@@ -9,10 +9,17 @@
       "type": "separator"
     },
 
+    "Location Appearance Matches Contents": {
+      "type": "toggle",
+      "value": true,
+      "tooltip": "Adjusts Nomai arc text color to match what quality of check it holds. Recommended to use with Auto Expand Nomai Text. Changes to this setting will only apply at the start of the next loop."
+      // remember to adjust tooltip as more features are covered by this
+    },
+
     "Auto Expand Nomai Text": {
       "type": "toggle",
       "value": false,
-      "tooltip": "With this on, all Nomai text in the game will start in an expanded state, allowing you to read it without having to wait for it to expand. This setting will only apply at the start of the next loop."
+      "tooltip": "With this on, all Nomai text in the game will start in an expanded state, allowing you to read it without having to wait for it to expand. Changes to this setting will only apply at the start of the next loop."
     },
 
     "Instant Translator": {

--- a/mod/default-config.json
+++ b/mod/default-config.json
@@ -9,7 +9,8 @@
       "type": "separator"
     },
 
-    "Location Appearance Matches Contents": {
+    "LocationAppearanceMatchesContents": {
+      "title": "Colorize Locations By AP Item Type",
       "type": "toggle",
       "value": true,
       "tooltip": "Adjusts Nomai arc text color to match what quality of check it holds. Recommended to use with Auto Expand Nomai Text. Changes to this setting will only apply at the start of the next loop."


### PR DESCRIPTION
* Nomai text arcs will now change their color to reflect what they contain (observes logsanity)
  * Junk items are cyan
  * Useful items are green
  * Progression items are magenta
  * Found items are white
  * Arcs without a check use their vanilla colors
* Nomai text arcs containing a trap will use a random color and change the texture of the arc to use the child arc texture (or adult texture if they're already a child arc)
* Added a config setting to make arcs reflect their contents
* Added scouting for every check in the game, can be used for hinting and more Location Match Contents features
* Fixed a bug that caused arcs that have manually been given a check, such as Solanum's school scroll, to not give checks when Auto Expand Nomai Text was on