### PR TITLE
Objects match contents: Scrolls

### DIFF
--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -63,7 +63,9 @@ public class APRandomizer : ModBehaviour
 
     public static bool AutoNomaiText = false;
     public static bool ColorNomaiText = true;
+    public static bool InstantTranslator = false;
 
+    public static bool HasSeenSettingsText = false;
     public static bool DisableConsole = false;
     public static bool DisableInGameLocationSending = false;
     private static bool DisableInGameItemReceiving = false;
@@ -571,7 +573,8 @@ public class APRandomizer : ModBehaviour
         // Configure() is called early and often, including before we create the Console
         AutoNomaiText = config.GetSettingsValue<bool>("Auto Expand Nomai Text");
         ColorNomaiText = config.GetSettingsValue<bool>("LocationAppearanceMatchesContents");
-        NomaiTextQoL.TranslateTime = config.GetSettingsValue<bool>("Instant Translator") ? 0f : 0.2f;
+        InstantTranslator = config.GetSettingsValue<bool>("Instant Translator");
+        NomaiTextQoL.TranslateTime = InstantTranslator ? 0f : 0.2f;
 
         DisableConsole = config.GetSettingsValue<bool>("[DEBUG] Disable In-Game Console");
         DisableInGameLocationSending = config.GetSettingsValue<bool>("[DEBUG] Don't Send Locations In-Game");
@@ -582,4 +585,5 @@ public class APRandomizer : ModBehaviour
         DeathLinkManager.ApplyOverrideSetting();
         SuitResources.ModSettingsChanged(config);
     }
+
 }

--- a/mod/ArcHintData.cs
+++ b/mod/ArcHintData.cs
@@ -70,7 +70,6 @@ namespace ArchipelagoRandomizer
 
         public void SetImportance(CheckImportance importance)
         {
-            APRandomizer.OWMLModConsole.WriteLine($"blehportant {Time.frameCount}", OWML.Common.MessageType.Warning);
             if ((int)Importance < (int)importance)
             {
                 Importance = importance;
@@ -105,7 +104,6 @@ namespace ArchipelagoRandomizer
                     break;
                 case ItemFlags.Trap:
                     int rnd = Random.Range(0, 3);
-                    APRandomizer.OWMLModConsole.WriteLine($"Trap set to {rnd}");
                     switch (rnd)
                     {
                         case 0:

--- a/mod/ArcHintData.cs
+++ b/mod/ArcHintData.cs
@@ -4,7 +4,10 @@ using Archipelago.MultiClient.Net.Enums;
 
 namespace ArchipelagoRandomizer
 {
-    public class CheckHintData : MonoBehaviour
+    /// <summary>
+    /// Determines the color of Nomai Text Arcs based on their contents
+    /// </summary>
+    public class ArcHintData : MonoBehaviour
     {
         // Since arcs have no idea which logs they're connected to,
         // we record them and their other location checks here in a list
@@ -12,14 +15,11 @@ namespace ArchipelagoRandomizer
         // Currently unused in any code but may use it later
         public List<Location> Locations = new List<Location>();
         public CheckImportance Importance = CheckImportance.Filler;
+        // used to show importance in case of traps
+        public CheckImportance DisplayImportance = CheckImportance.Trap;
         public bool HasBeenFound = false;
 
         private bool IsChildText = false;
-
-        public static readonly Color JunkColor = new(0.5f, 1.5f, 1.5f, 1);
-        public static readonly Color UsefulColor = new(0.5f, 1.8f, 0.5f, 1);
-        public static readonly Color ProgressionColor = new(1.5f, 0.5f, 1.5f, 1);
-        public static readonly Color FoundColor = new(1.2f, 1.2f, 1.2f, 1);
 
         public static Material ChildTextMat
         {
@@ -52,26 +52,32 @@ namespace ArchipelagoRandomizer
 
         public Color NomaiWallColor()
         {
-            if (HasBeenFound) return FoundColor;
+            if (HasBeenFound) return HintColors.FoundColor;
             switch (Importance)
             {
                 case CheckImportance.Filler:
-                    return JunkColor;
+                    DisplayImportance = CheckImportance.Filler;
+                    return HintColors.FillerColor;
                 case CheckImportance.Useful:
-                    return UsefulColor;
+                    DisplayImportance = CheckImportance.Useful;
+                    return HintColors.UsefulColor;
                 case CheckImportance.Progression:
-                    return ProgressionColor;
+                    DisplayImportance = CheckImportance.Progression;
+                    return HintColors.ProgressionColor;
                 default:
                     {
                         int rnd = Random.Range(0, 3);
                         switch (rnd)
                         {
                             case 0:
-                                return JunkColor;
+                                DisplayImportance = CheckImportance.Filler;
+                                return HintColors.FillerColor;
                             case 1:
-                                return UsefulColor;
+                                DisplayImportance = CheckImportance.Useful;
+                                return HintColors.UsefulColor;
                             default:
-                                return ProgressionColor;
+                                DisplayImportance = CheckImportance.Progression;
+                                return HintColors.ProgressionColor;
                         }    
                     }
             }
@@ -115,11 +121,5 @@ namespace ArchipelagoRandomizer
             }
         }
     }
-    public enum CheckImportance
-    {
-        Trap = 0,
-        Filler = 1,
-        Useful = 2,
-        Progression = 3
-    }
+    
 }

--- a/mod/ArcHintData.cs
+++ b/mod/ArcHintData.cs
@@ -53,7 +53,7 @@ namespace ArchipelagoRandomizer
         public Color NomaiWallColor()
         {
             if (HasBeenFound) return HintColors.FoundColor;
-            switch (Importance)
+            switch (DisplayImportance)
             {
                 case CheckImportance.Filler:
                     DisplayImportance = CheckImportance.Filler;
@@ -64,27 +64,13 @@ namespace ArchipelagoRandomizer
                 case CheckImportance.Progression:
                     DisplayImportance = CheckImportance.Progression;
                     return HintColors.ProgressionColor;
-                default:
-                    {
-                        int rnd = Random.Range(0, 3);
-                        switch (rnd)
-                        {
-                            case 0:
-                                DisplayImportance = CheckImportance.Filler;
-                                return HintColors.FillerColor;
-                            case 1:
-                                DisplayImportance = CheckImportance.Useful;
-                                return HintColors.UsefulColor;
-                            default:
-                                DisplayImportance = CheckImportance.Progression;
-                                return HintColors.ProgressionColor;
-                        }    
-                    }
+                default: return Color.red;
             }
         }
 
         public void SetImportance(CheckImportance importance)
         {
+            APRandomizer.OWMLModConsole.WriteLine($"blehportant {Time.frameCount}", OWML.Common.MessageType.Warning);
             if ((int)Importance < (int)importance)
             {
                 Importance = importance;
@@ -106,16 +92,33 @@ namespace ArchipelagoRandomizer
             switch (LocationScouter.ScoutedLocations[loc].Flags)
             {
                 case ItemFlags.None:
+                    DisplayImportance = CheckImportance.Filler;
                     SetImportance(CheckImportance.Filler);
                     break;
                 case ItemFlags.NeverExclude:
+                    DisplayImportance = CheckImportance.Useful;
                     SetImportance(CheckImportance.Useful);
                     break;
                 case ItemFlags.Advancement:
+                    DisplayImportance = CheckImportance.Progression;
                     SetImportance(CheckImportance.Progression);
                     break;
                 case ItemFlags.Trap:
-                    SetImportance(CheckImportance.Trap);
+                    int rnd = Random.Range(0, 3);
+                    APRandomizer.OWMLModConsole.WriteLine($"Trap set to {rnd}");
+                    switch (rnd)
+                    {
+                        case 0:
+                            DisplayImportance = CheckImportance.Filler;
+                            break;
+                        case 1:
+                            DisplayImportance = CheckImportance.Useful;
+                            break;
+                        default:
+                            DisplayImportance = CheckImportance.Progression;
+                            break;
+                    }
+                    SetImportance(DisplayImportance);
                     rend.material = IsChildText ? NormalTextMat : ChildTextMat;
                     break;
             }

--- a/mod/ArchConsoleManager.cs
+++ b/mod/ArchConsoleManager.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
+using static ArchipelagoRandomizer.DeathLinkManager;
 
 namespace ArchipelagoRandomizer;
 
@@ -68,6 +69,7 @@ public class ArchConsoleManager : MonoBehaviour
         {
             s.Locations.CheckedLocationsUpdated += UpdateProgress;
             session = s;
+            APRandomizer.HasSeenSettingsText = false;
         };
 
         // Show the correct version of the console depending on if the game is paused or not
@@ -167,9 +169,11 @@ public class ArchConsoleManager : MonoBehaviour
             AddText(entry);
         WakeupConsoleMessages.Clear();
 
-        string dlMessage = DeathLinkManager.GetDeathLinkWakeupConsoleMessage();
-        if (dlMessage != null)
-            AddText(dlMessage);
+        if (!APRandomizer.HasSeenSettingsText)
+        {
+            AddText(GetSettingsMessage());
+            APRandomizer.HasSeenSettingsText = true;
+        }
 
         UpdateProgress();
 
@@ -467,5 +471,22 @@ public class ArchConsoleManager : MonoBehaviour
     {
         yield return new WaitForEndOfFrame();
         AddText($"<color=#6BFF6B>Welcome to your {LoopNumber()} loop!</color>", true);
+    }
+
+    private static string GetSettingsMessage()
+    {
+        string settingsString = "Settings:\n";
+
+        if (overrideSetting != null)
+            settingsString += $"Death Link: {DeathLinkManager.overrideSetting} (Overriding {DeathLinkManager.slotDataSetting})\n";
+        else if (DeathLinkManager.slotDataSetting != DeathLinkSetting.Off)
+            settingsString += $"Death Link: {DeathLinkManager.slotDataSetting}\n";
+        settingsString += $"Colorize Locations By AP Item Type: {(APRandomizer.ColorNomaiText ? "<color=lime>ON</color>" : "<color=red>OFF</color>")}\n" +
+            $"Auto-Expand Nomai Text: {(APRandomizer.AutoNomaiText ? "<color=lime>ON</color>" : "<color=red>OFF</color>")}\n" +
+            $"Instant Translator: {(APRandomizer.InstantTranslator ? "<color=lime>ON</color>" : "<color=red>OFF</color>")}\n" +
+            $"You can change these in the mod config settings. If racing, make sure to observe the settings of the race.";
+
+
+        return settingsString;
     }
 }

--- a/mod/CheckImportance.cs
+++ b/mod/CheckImportance.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ArchipelagoRandomizer
+{
+    public enum CheckImportance
+    {
+        Trap = 0,
+        Filler = 1,
+        Useful = 2,
+        Progression = 3
+    }
+}

--- a/mod/DeathLinkManager.cs
+++ b/mod/DeathLinkManager.cs
@@ -6,17 +6,17 @@ using System.Collections.Generic;
 namespace ArchipelagoRandomizer;
 
 [HarmonyPatch]
-internal class DeathLinkManager
+public class DeathLinkManager
 {
-    enum DeathLinkSetting: long
+    public enum DeathLinkSetting: long
     {
         Off = 0,
         Default = 1,
         AllDeaths = 2,
     }
 
-    private static DeathLinkSetting slotDataSetting = DeathLinkSetting.Off;
-    private static DeathLinkSetting? overrideSetting = null; // a null here represents 'No Override' / use slotDataSetting
+    public static DeathLinkSetting slotDataSetting = DeathLinkSetting.Off;
+    public static DeathLinkSetting? overrideSetting = null; // a null here represents 'No Override' / use slotDataSetting
 
     private static DeathLinkSetting effectiveSetting = DeathLinkSetting.Off;
 
@@ -77,15 +77,6 @@ internal class DeathLinkManager
         }
     }
 
-    public static string GetDeathLinkWakeupConsoleMessage()
-    {
-        if (overrideSetting != null)
-            return $"Death Link Override is set to: {overrideSetting}. (Ignoring .yaml option value for this multiworld: {slotDataSetting})";
-        else if (slotDataSetting != DeathLinkSetting.Off)
-            return $"Death Link option for this multiworld: {slotDataSetting}";
-
-        return null;
-    }
 
     // useful for testing
     /*[HarmonyPrefix, HarmonyPatch(typeof(ToolModeUI), nameof(ToolModeUI.Update))]

--- a/mod/HintColors.cs
+++ b/mod/HintColors.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+namespace ArchipelagoRandomizer
+{
+    /// <summary>
+    /// Colors for locations match contents
+    /// </summary>
+    public static class HintColors
+    {
+        public static readonly Color FillerColor = new(0.5f, 1.5f, 1.5f, 1);
+        public static readonly Color UsefulColor = new(0.5f, 1.8f, 0.5f, 1);
+        public static readonly Color ProgressionColor = new(1.5f, 0.5f, 1.5f, 1);
+        public static readonly Color FoundColor = new(1.2f, 1.2f, 1.2f, 1);
+        public static readonly Color FillerColorTrim = new(0.8f, 1.8f, 1.8f, 1);
+        public static readonly Color UsefulColorTrim = new(0.8f, 2f, 0.8f, 1);
+        public static readonly Color ProgressionColorTrim = new(1.8f, 0.8f, 1.8f, 1);
+        public static readonly Color FoundColorTrim = new(1.5f, 1.5f, 1.5f, 1);
+    }
+}

--- a/mod/HintColors.cs
+++ b/mod/HintColors.cs
@@ -11,9 +11,9 @@ namespace ArchipelagoRandomizer
         public static readonly Color UsefulColor = new(0.5f, 1.8f, 0.5f, 1);
         public static readonly Color ProgressionColor = new(1.5f, 0.5f, 1.5f, 1);
         public static readonly Color FoundColor = new(1.2f, 1.2f, 1.2f, 1);
-        public static readonly Color FillerColorTrim = new(0.8f, 1.8f, 1.8f, 1);
-        public static readonly Color UsefulColorTrim = new(0.8f, 2f, 0.8f, 1);
-        public static readonly Color ProgressionColorTrim = new(1.8f, 0.8f, 1.8f, 1);
+        public static readonly Color FillerColorTrim = new(0f, 1f, 1f, 1);
+        public static readonly Color UsefulColorTrim = new(0f, 1.5f, 0f, 1);
+        public static readonly Color ProgressionColorTrim = new(1.5f, 0f, 1.5f, 1);
         public static readonly Color FoundColorTrim = new(1.5f, 1.5f, 1.5f, 1);
     }
 }

--- a/mod/LocationScouter.cs
+++ b/mod/LocationScouter.cs
@@ -26,6 +26,7 @@ namespace ArchipelagoRandomizer
             if (APRandomizer.SaveData.scoutedLocations != null)
             {
                 ScoutedLocations = APRandomizer.SaveData.scoutedLocations;
+                APRandomizer.OWMLModConsole.WriteLine($"Scouted locations loaded from save file.", OWML.Common.MessageType.Success);
                 return;
             }
 
@@ -65,7 +66,7 @@ namespace ArchipelagoRandomizer
             }));
             if (!scoutTask.Wait(TimeSpan.FromSeconds(5)))
             {
-                APRandomizer.OWMLModConsole.WriteLine("Scouting failed! Hints will not be available this session.", OWML.Common.MessageType.Error);
+                APRandomizer.OWMLModConsole.WriteLine("Scouting failed! Hints will not be available this session. There was likely an APWorld mismatch, check the server logs for more info.", OWML.Common.MessageType.Error);
             }
         }
     }

--- a/mod/NomaiTextQoL.cs
+++ b/mod/NomaiTextQoL.cs
@@ -32,7 +32,7 @@ namespace ArchipelagoRandomizer
                     // fix for single arcs
                     if (__instance._textLines.Length == 1)
                     {
-                        CheckHintData hintData = __instance._textLines[0].gameObject.GetAddComponent<CheckHintData>();
+                        ArcHintData hintData = __instance._textLines[0].gameObject.GetAddComponent<ArcHintData>();
 
                         // DatabaseID is the ship log name
                         string log = nomaiTextData.DatabaseID;
@@ -63,7 +63,7 @@ namespace ArchipelagoRandomizer
                             {
                                 var textLine = __instance._textLines.First(x => x.GetEntryID() == key);
 
-                                CheckHintData hintData = textLine.gameObject.GetAddComponent<CheckHintData>();
+                                ArcHintData hintData = textLine.gameObject.GetAddComponent<ArcHintData>();
 
                                 // DatabaseID is the ship log name
                                 string log = nomaiTextData.DatabaseID;
@@ -90,7 +90,7 @@ namespace ArchipelagoRandomizer
                 if (LocationTriggers.ManualScrollLocations.ContainsKey(name))
                 {
                     NomaiTextLine textLine = __instance.transform.GetComponentInChildren<NomaiTextLine>();
-                    CheckHintData hintData = textLine.gameObject.GetAddComponent<CheckHintData>();
+                    ArcHintData hintData = textLine.gameObject.GetAddComponent<ArcHintData>();
 
                     hintData.DetermineImportance(LocationTriggers.ManualScrollLocations[name]);
                 }
@@ -118,7 +118,7 @@ namespace ArchipelagoRandomizer
         [HarmonyPrefix, HarmonyPatch(typeof(NomaiTextLine), nameof(NomaiTextLine.DetermineTextLineColor))]
         public static bool NomaiTextLine_DetermineTextLineColor_Prefix(NomaiText __instance, ref NomaiTextLine.VisualState state, ref Color __result)
         {
-            CheckHintData data = __instance.GetComponent<CheckHintData>();
+            ArcHintData data = __instance.GetComponent<ArcHintData>();
             if (!ColorNomaiText || data == null || state != NomaiTextLine.VisualState.UNREAD || data.Locations.Count == 0)
             {
                 return true;
@@ -203,6 +203,13 @@ namespace ArchipelagoRandomizer
         public static void NomaiTranslatorProp_SwitchTextNode_Prefix(NomaiTranslatorProp __instance)
         {
             __instance._totalTranslateTime = TranslateTime;
+        }
+
+        // Setting up scrolls to show contents
+        [HarmonyPostfix, HarmonyPatch(typeof(ScrollItem), nameof(ScrollItem.Awake))]
+        public static void ScrollItem_Awake_Postfix(ScrollItem __instance)
+        {
+            __instance.gameObject.AddComponent<ScrollHintData>();
         }
     }
 }

--- a/mod/NomaiTextQoL.cs
+++ b/mod/NomaiTextQoL.cs
@@ -52,6 +52,8 @@ namespace ArchipelagoRandomizer
                         continue;
                     }
 
+                    if (__instance._listDBConditions[i].LocationCondition != NomaiText.Location.UNSPECIFIED && __instance._listDBConditions[i].LocationCondition != __instance._location) continue;
+
                     for (int j = 0; j < nomaiTextData.ConditionBlock.Length; j++)
                     {
                         for (int k = 0; k < nomaiTextData.ConditionBlock[j].Length; k++)
@@ -62,6 +64,7 @@ namespace ArchipelagoRandomizer
                             if (__instance._dictNomaiTextData.ContainsKey(key))
                             {
                                 var textLine = __instance._textLines.First(x => x.GetEntryID() == key);
+                                
 
                                 ArcHintData hintData = textLine.gameObject.GetAddComponent<ArcHintData>();
 

--- a/mod/NomaiTextQoL.cs
+++ b/mod/NomaiTextQoL.cs
@@ -209,7 +209,7 @@ namespace ArchipelagoRandomizer
         [HarmonyPostfix, HarmonyPatch(typeof(ScrollItem), nameof(ScrollItem.Awake))]
         public static void ScrollItem_Awake_Postfix(ScrollItem __instance)
         {
-            __instance.gameObject.AddComponent<ScrollHintData>();
+            if (ColorNomaiText) __instance.gameObject.AddComponent<ScrollHintData>();
         }
     }
 }

--- a/mod/ScrollHintData.cs
+++ b/mod/ScrollHintData.cs
@@ -68,7 +68,6 @@ namespace ArchipelagoRandomizer
             }
             rend.material.SetColor("_Detail1EmissionColor", textColor);
             rend.material.SetColor("_Detail3EmissionColor", trimColor);
-            APRandomizer.OWMLModConsole.WriteLine($"Scroll that's the child of {transform.parent.name} has been given the color relating to importance {importance}");
         }
     }
 }

--- a/mod/ScrollHintData.cs
+++ b/mod/ScrollHintData.cs
@@ -1,0 +1,77 @@
+﻿using Steamworks;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace ArchipelagoRandomizer
+{
+    /// <summary>
+    /// Sets the colors of scroll text and 
+    /// </summary>
+    public class ScrollHintData : MonoBehaviour
+    {
+        // since scrolls don't have a good way to see if they're traps, Trap can simply mean empty here
+        private CheckImportance importance = CheckImportance.Trap;
+
+        private void Start()
+        {
+            APRandomizer.OWMLModConsole.WriteLine("bleh", OWML.Common.MessageType.Success);
+            StartCoroutine(SetScrollColors());
+        }
+
+        IEnumerator SetScrollColors()
+        {
+            // want to make sure all text has been initialized properly, so we wait a few frames
+            yield return new WaitForEndOfFrame();
+            yield return new WaitForEndOfFrame();
+            yield return new WaitForEndOfFrame();
+            Renderer rend = transform.Find("Props_NOM_Scroll/Props_NOM_Scroll_Geo").GetComponent<Renderer>();
+            ArcHintData[] arcs = GetComponentsInChildren<ArcHintData>();
+            // We can ignore trying to change scroll colors if there are no hints found
+            if (arcs.Length == 0) yield break;
+            importance = arcs.Max(x => x.DisplayImportance);
+            Color textColor = Color.white;
+            Color trimColor = Color.white;
+            if (arcs.All(x => x.HasBeenFound))
+            {
+                textColor = HintColors.FoundColor;
+                trimColor = HintColors.FoundColorTrim;
+            }
+            else switch (importance)
+            {
+                case CheckImportance.Filler:
+                {
+                    textColor = HintColors.FillerColor;
+                    trimColor = HintColors.FillerColorTrim;
+                    break;
+                }
+                case CheckImportance.Useful:
+                {
+                    textColor = HintColors.UsefulColor;
+                    trimColor = HintColors.UsefulColorTrim;
+                    break;
+                }
+                case CheckImportance.Progression:
+                {
+                    textColor = HintColors.FillerColor;
+                    trimColor = HintColors.FillerColorTrim;
+                    break;
+                }
+                default:
+                {
+                    APRandomizer.OWMLModConsole.WriteLine($"Uh this code shouldn't have been reached, the scroll at {transform.parent.name} somehow didn't inherit an importance priority.", OWML.Common.MessageType.Error);
+                    textColor = Color.red;
+                    trimColor = Color.red;
+                    break;
+                }
+            }
+            rend.material.SetColor("_Detail1EmissionColor", textColor);
+            rend.material.SetColor("_Detail3EmissionColor", trimColor);
+            APRandomizer.OWMLModConsole.WriteLine($"Scroll has been given the color relating to importance {importance}");
+        }
+    }
+}


### PR DESCRIPTION
* Scrolls will now reflect the highest quality item within their arcs
  * They will use the color of trap arcs if the trap arc is the highest quality between the arcs
* Fixed a bug where traps were always marked as filler
* The message that appears mentioning your deathlink setting has been changed:
  * The text mentioning your deathlink setting is more concise
  * Colorize Locations, Auto Expand Nomai Text, and Instant Translator report their settings
  * The text mentions you can change your settings in the mod config and reminds you to observe race settings
  * The text now only appears on your first loop of the session instead of every loop