### PR TITLE
Add support for the suit log (issue #35)

### DIFF
--- a/mod/InGameTracker/APChecklistMode.cs
+++ b/mod/InGameTracker/APChecklistMode.cs
@@ -27,7 +27,6 @@ public class APChecklistMode : ShipLogMode
 
     public bool IsInChecklist = false;
 
-    private GameObject shipLogPanRoot;
     Dictionary<string, TrackerChecklistData> LocationNameToChecklistData;
 
     private Material selectorMaterial;
@@ -348,15 +347,16 @@ public class APChecklistMode : ShipLogMode
         return "";
     }
     
-    // gets the ship log image for the associated fact
-    private Sprite GetShipLogImage(string fact)
+    // gets the ship log image for the associated entry ID
+    private Sprite GetShipLogImage(string entryId)
     {
-        if (string.IsNullOrEmpty(fact))
+        if (string.IsNullOrEmpty(entryId))
         {
             return TrackerManager.GetSprite("PLACEHOLDER");
         }
-        if (shipLogPanRoot == null) shipLogPanRoot = Locator.GetShipBody().gameObject.transform.Find("Module_Cabin/Systems_Cabin/ShipLogPivot/ShipLog/ShipLogPivot/ShipLogCanvas/DetectiveMode/ScaleRoot/PanRoot").gameObject;
-        Sprite sprite = shipLogPanRoot.transform.Find($"{fact}/EntryCardRoot/EntryCardBackground/PhotoImage")?.GetComponent<Image>()?.sprite;
+
+        Sprite sprite = Locator.GetShipLogManager().GetEntry(entryId)?.GetSprite();
+
         if (!sprite)
         {
             return TrackerManager.GetSprite("OTHER_SYSTEM_PLACEHOLDER");

--- a/mod/InGameTracker/ISuitLogAPI.cs
+++ b/mod/InGameTracker/ISuitLogAPI.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace ArchipelagoRandomizer.InGameTracker;
+
+public interface ISuitLogAPI
+{
+    public void AddMode(ShipLogMode mode, Func<bool> isEnabledSupplier, Func<string> nameSupplier);
+
+    public void ItemListMake(Action<MonoBehaviour> callback);
+    public void ItemListOpen(MonoBehaviour itemList);
+    public void ItemListClose(MonoBehaviour itemList);
+    public int ItemListUpdateList(MonoBehaviour itemList);
+    public void ItemListUpdateListUI(MonoBehaviour itemList);
+    public void ItemListSetName(MonoBehaviour itemList, string nameValue);
+    public void ItemListSetItems(MonoBehaviour itemList, List<Tuple<string, bool, bool, bool>> items);
+    public int ItemListGetSelectedIndex(MonoBehaviour itemList);
+    public void ItemListSetSelectedIndex(MonoBehaviour itemList, int index);
+    public Image ItemListGetPhoto(MonoBehaviour itemList);
+    public Text ItemListGetQuestionMark(MonoBehaviour itemList);
+    public void ItemListDescriptionFieldClear(MonoBehaviour itemList);
+    public ShipLogFactListItem ItemListDescriptionFieldGetNextItem(MonoBehaviour itemList);
+    public void ItemListDescriptionFieldOpen(MonoBehaviour itemList);
+    public void ItemListDescriptionFieldClose(MonoBehaviour itemList);
+    public List<ShipLogEntryListItem> ItemListGetItemsUI(MonoBehaviour itemList);
+    public int ItemListGetIndexUI(MonoBehaviour itemList, int index);
+}

--- a/mod/InGameTracker/ItemListWrapper.cs
+++ b/mod/InGameTracker/ItemListWrapper.cs
@@ -1,176 +1,212 @@
-﻿using System;
+/**
+ * Courtesy of the Ship Log Slide Reel Player Plus mod
+ */
+
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
 namespace ArchipelagoRandomizer.InGameTracker;
 
-public class ItemListWrapper
+public abstract class ItemListWrapper
+{
+    protected MonoBehaviour _itemList;
+
+    public abstract void Open();
+    public abstract void Close();
+    public abstract int UpdateList();
+    public abstract void UpdateListUI();
+    public abstract void SetName(string nameValue);
+    public abstract void SetItems(List<Tuple<string, bool, bool, bool>> items);
+    public abstract int GetSelectedIndex();
+    public abstract void SetSelectedIndex(int index);
+    public abstract Image GetPhoto();
+    public abstract Text GetQuestionMark();
+    public abstract void DescriptionFieldClear();
+    public abstract ShipLogFactListItem DescriptionFieldGetNextItem();
+    public abstract List<ShipLogEntryListItem> GetItemsUI();
+    public abstract int GetIndexUI(int index);
+}
+
+public class ShipLogItemListWrapper : ItemListWrapper
 {
     private readonly ICustomShipLogModesAPI _api;
-    private readonly MonoBehaviour _itemList;
 
-    public ItemListWrapper(ICustomShipLogModesAPI api, MonoBehaviour itemList)
+    public ShipLogItemListWrapper(ICustomShipLogModesAPI api, MonoBehaviour itemList)
     {
-        _api = api;
         _itemList = itemList;
+        _api = api;
     }
 
-    /// <summary>
-    /// Displays the item list UI the Ship Log computer screen. The elements are displayed using animations. You could use this method for example in the EnterMode of your custom mode.
-    /// </summary>
-    public void Open()
+    public override void Open()
     {
         _api.ItemListOpen(_itemList);
     }
 
-    /// <summary>
-    /// Hides the item list UI, also with animations. You could use this method for example in the ExitMode of your custom mode.
-    /// </summary>
-    public void Close()
+    public override void Close()
     {
         _api.ItemListClose(_itemList);
     }
 
-    /// <summary>
-    /// If there are at least two items, takes the user input to navigate the list, changing the selected item in that case. 
-    /// The returned int value indicates how much the index of the selected item changed (-1 means that the selection was changed to the item above, 0 that the selection wasn't changed, and 1 that the selection was changed to the item below). 
-    /// You could use that value for example to know if you should display things in the description field or change the photo image.
-    /// </summary>
-    /// <returns></returns>
-    public int UpdateList()
+    public override int UpdateList()
     {
         return _api.ItemListUpdateList(_itemList);
     }
 
-    /// <summary>
-    /// Similar to UpdateList but this just updates the UI, it doesn't take the user input to navigate the list (and doesn't return a value).
-    /// </summary>
-    public void UpdateListUI()
+    public override void UpdateListUI()
     {
         _api.ItemListUpdateListUI(_itemList);
     }
 
-    /// <summary>
-    /// Changes the text showed above the list of items, by default it displays the empty string "". You could change it to display the name of your mode for example.
-    /// </summary>
-    /// <param name="nameValue"></param>
-    public void SetName(string nameValue)
+    public override void SetName(string nameValue)
     {
         _api.ItemListSetName(_itemList, nameValue);
     }
 
-    /// <summary>
-    /// Sets the items of the list, each of them is represented by a Tuple with 4 elements that are used to display the item in the list.
-    /// String is name of the list.
-    /// First bool indicates if the green down arrow should be shown
-    /// Second bool indicates whether the green exclamation point should be shown
-    /// Third bool indicates whether the the orange asterisk should be shown
-    /// </summary>
-    /// <param name="items"></param>
-    public void SetItems(List<Tuple<string, bool, bool, bool>> items)
+    public override void SetItems(List<Tuple<string, bool, bool, bool>> items)
     {
         _api.ItemListSetItems(_itemList, items);
     }
 
-    /// <summary>
-    /// Returns the zero-based index of the selected index (0 is the first, 1 is the second and so on). 
-    /// Note that, for example, if this returns 6 it doesn't mean that this is the seventh element currently displayed counting from above, because of the scrolling. 
-    /// In fact, all items with index >= 4 will be at the fifth displayed item when selected.
-    /// </summary>
-    /// <returns></returns>
-    public int GetSelectedIndex()
+    public override int GetSelectedIndex()
     {
         return _api.ItemListGetSelectedIndex(_itemList);
     }
 
-    /// <summary>
-    /// Changes the index of the selected index. For example, when the user enters to your mode, you may want the item list to be positioned at a particular index.
-    /// </summary>
-    /// <param name="index"></param>
-    public void SetSelectedIndex(int index)
+    public override void SetSelectedIndex(int index)
     {
         _api.ItemListSetSelectedIndex(_itemList, index);
     }
 
-    /// <summary>
-    /// Returns the Image component of the object used to display images available if the item list was configured with usePhoto = true. The object is disabled by default, you may enable it and set its sprite to any image you want.
-    /// </summary>
-    /// <returns></returns>
-    public Image GetPhoto()
+    public override Image GetPhoto()
     {
         return _api.ItemListGetPhoto(_itemList);
     }
 
-    /// <summary>
-    /// Returns the Text component of the object used to display a text (by default an orange question mark that in vanilla is used for rumored entries) at the same space where the photo is, 
-    /// available if the item list was configured with usePhoto = true. 
-    /// The object is disabled by default, you may enable if and set its sprite to any text you want (it doesn't have to necessarily be a question mark, it could be anything).
-    /// </summary>
-    /// <returns></returns>
-    public Text GetQuestionMark()
+    public override Text GetQuestionMark()
     {
         return _api.ItemListGetQuestionMark(_itemList);
     }
 
-    /// <summary>
-    /// Clears the shared description field (ShipLogEntryDescriptionField) used by other item lists and the vanilla Rumor Mode and Map Mode. 
-    /// It's similar to the vanilla SetText method of ShipLogEntryDescriptionField but instead of clearing all but one fact items, it clears them all.
-    /// </summary>
-    public void DescriptionFieldClear()
+    public override void DescriptionFieldClear()
     {
         _api.ItemListDescriptionFieldClear(_itemList);
     }
 
-    /// <summary>
-    /// Displays the next ShipLogFactListItem with an empty string (intended to be changed by you). 
-    /// It also returns that newly displayed ShipLogFactListItem, that you would use to display any text you want (you could use the DisplayText method of the item for example).
-    /// </summary>
-    /// <returns></returns>
-    public ShipLogFactListItem DescriptionFieldGetNextItem()
+    public override ShipLogFactListItem DescriptionFieldGetNextItem()
     {
         return _api.ItemListDescriptionFieldGetNextItem(_itemList);
     }
 
-    /// <summary>
-    /// Makes the "Mark on HUD" rectangle object active or inactive depending on the parameter (this object starts disabled by default). 
-    /// This root includes the border, background and the screen prompts that are displayed in the lower part of the photo or question mark square (and so it could cover part of the photo), 
-    /// all these elements are made visible or invsible using this method.
-    /// </summary>
-    /// <param name="enable"></param>
+    public override List<ShipLogEntryListItem> GetItemsUI()
+    {
+        return _api.ItemListGetItemsUI(_itemList);
+    }
+
+    public override int GetIndexUI(int index)
+    {
+        return _api.ItemListGetIndexUI(_itemList, index);
+    }
+
     public void MarkHUDRootEnable(bool enable)
     {
         _api.ItemListMarkHUDRootEnable(_itemList, enable);
     }
 
-    /// <summary>
-    /// Returns the ScreenPromptList of the "Mark on HUD" rectangle, initially empty (no prompts), so you could add your prompts.
-    /// </summary>
-    /// <returns></returns>
     public ScreenPromptList MarkHUDGetPromptList()
     {
         return _api.ItemListMarkHUDGetPromptList(_itemList);
     }
+}
 
-    /// <summary>
-    /// Returns the list of all ShipLogEntryListItem used to display the items in order from top to bottom. 
-    /// All UI items are returned, including the ones that aren't currently used to display elements, and in fact 14 items are always returned even if the description field is used 
-    /// (that only allows 7 items to be displayed at most), because the others items are never destroyed when creating the list (this detail isn't probably relevant to you but just in case).
-    /// </summary>
-    /// <returns></returns>
-    public List<ShipLogEntryListItem> GetItemsUI()
+public class SuitLogItemListWrapper : ItemListWrapper
+{
+    private readonly ISuitLogAPI _api;
+
+    public SuitLogItemListWrapper(ISuitLogAPI api, MonoBehaviour itemList)
+    {
+        _itemList = itemList;
+        _api = api;
+    }
+
+    public override void Open()
+    {
+        _api.ItemListOpen(_itemList);
+    }
+
+    public override void Close()
+    {
+        _api.ItemListClose(_itemList);
+    }
+
+    public override int UpdateList()
+    {
+        return _api.ItemListUpdateList(_itemList);
+    }
+
+    public override void UpdateListUI()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void SetName(string nameValue)
+    {
+        _api.ItemListSetName(_itemList, nameValue);
+    }
+
+    public override void SetItems(List<Tuple<string, bool, bool, bool>> items)
+    {
+        _api.ItemListSetItems(_itemList, items);
+    }
+
+    public override int GetSelectedIndex()
+    {
+        return _api.ItemListGetSelectedIndex(_itemList);
+    }
+
+    public override void SetSelectedIndex(int index)
+    {
+        _api.ItemListSetSelectedIndex(_itemList, index);
+    }
+
+    public override Image GetPhoto()
+    {
+        return _api.ItemListGetPhoto(_itemList);
+    }
+
+    public override Text GetQuestionMark()
+    {
+        return _api.ItemListGetQuestionMark(_itemList);
+    }
+
+    public override void DescriptionFieldClear()
+    {
+        _api.ItemListDescriptionFieldClear(_itemList);
+    }
+
+    public override ShipLogFactListItem DescriptionFieldGetNextItem()
+    {
+        return _api.ItemListDescriptionFieldGetNextItem(_itemList);
+    }
+
+    public override List<ShipLogEntryListItem> GetItemsUI()
     {
         return _api.ItemListGetItemsUI(_itemList);
     }
 
-    /// <summary>
-    /// Returns the index of the UI item used to display the item with the given index, or -1 if the item with index isn't currently displayed (because of scrolling). This could be combined with GetItemsUI. 
-    /// For example, itemListWrapper.GetItemsUI()[itemListWrapper.GetIndexUI(itemListWrapper.GetSelectedIndex())] returns the ShipLogEntryListItem of the currently selected item.
-    /// </summary>
-    /// <param name="index"></param>
-    /// <returns></returns>
-    public int GetIndexUI(int index)
+    public override int GetIndexUI(int index)
     {
         return _api.ItemListGetIndexUI(_itemList, index);
+    }
+
+    public void DescriptionFieldOpen()
+    {
+        _api.ItemListDescriptionFieldOpen(_itemList);
+    }
+
+    public void DescriptionFieldClose()
+    {
+        _api.ItemListDescriptionFieldClose(_itemList);
     }
 }

--- a/mod/InGameTracker/ItemListWrapper.cs
+++ b/mod/InGameTracker/ItemListWrapper.cs
@@ -13,19 +13,100 @@ public abstract class ItemListWrapper
 {
     protected MonoBehaviour _itemList;
 
+    /// <summary>
+    /// Displays the item list UI the Ship Log computer screen. The elements are displayed using animations. You could use this method for example in the EnterMode of your custom mode.
+    /// </summary>
     public abstract void Open();
+
+    /// <summary>
+    /// Hides the item list UI, also with animations. You could use this method for example in the ExitMode of your custom mode.
+    /// </summary>
     public abstract void Close();
+
+    /// <summary>
+    /// If there are at least two items, takes the user input to navigate the list, changing the selected item in that case.
+    /// The returned int value indicates how much the index of the selected item changed (-1 means that the selection was changed to the item above, 0 that the selection wasn't changed, and 1 that the selection was changed to the item below).
+    /// You could use that value for example to know if you should display things in the description field or change the photo image.
+    /// </summary>
+    /// <returns></returns>
     public abstract int UpdateList();
+
+    /// <summary>
+    /// Similar to UpdateList but this just updates the UI, it doesn't take the user input to navigate the list (and doesn't return a value).
+    /// </summary>
     public abstract void UpdateListUI();
+
+    /// <summary>
+    /// Changes the text showed above the list of items, by default it displays the empty string "". You could change it to display the name of your mode for example.
+    /// </summary>
+    /// <param name="nameValue"></param>
     public abstract void SetName(string nameValue);
+
+    /// <summary>
+    /// Sets the items of the list, each of them is represented by a Tuple with 4 elements that are used to display the item in the list.
+    /// String is name of the list.
+    /// First bool indicates if the green down arrow should be shown
+    /// Second bool indicates whether the green exclamation point should be shown
+    /// Third bool indicates whether the the orange asterisk should be shown
+    /// </summary>
+    /// <param name="items"></param>
     public abstract void SetItems(List<Tuple<string, bool, bool, bool>> items);
+
+    /// <summary>
+    /// Returns the zero-based index of the selected index (0 is the first, 1 is the second and so on).
+    /// Note that, for example, if this returns 6 it doesn't mean that this is the seventh element currently displayed counting from above, because of the scrolling.
+    /// In fact, all items with index >= 4 will be at the fifth displayed item when selected.
+    /// </summary>
+    /// <returns></returns>
     public abstract int GetSelectedIndex();
+
+    /// <summary>
+    /// Changes the index of the selected index. For example, when the user enters to your mode, you may want the item list to be positioned at a particular index.
+    /// </summary>
+    /// <param name="index"></param>
     public abstract void SetSelectedIndex(int index);
+
+    /// <summary>
+    /// Returns the Image component of the object used to display images available if the item list was configured with usePhoto = true. The object is disabled by default, you may enable it and set its sprite to any image you want.
+    /// </summary>
+    /// <returns></returns>
     public abstract Image GetPhoto();
+
+    /// <summary>
+    /// Returns the Text component of the object used to display a text (by default an orange question mark that in vanilla is used for rumored entries) at the same space where the photo is,
+    /// available if the item list was configured with usePhoto = true.
+    /// The object is disabled by default, you may enable if and set its sprite to any text you want (it doesn't have to necessarily be a question mark, it could be anything).
+    /// </summary>
+    /// <returns></returns>
     public abstract Text GetQuestionMark();
+
+    /// <summary>
+    /// Clears the shared description field (ShipLogEntryDescriptionField) used by other item lists and the vanilla Rumor Mode and Map Mode.
+    /// It's similar to the vanilla SetText method of ShipLogEntryDescriptionField but instead of clearing all but one fact items, it clears them all.
+    /// </summary>
     public abstract void DescriptionFieldClear();
+
+    /// <summary>
+    /// Displays the next ShipLogFactListItem with an empty string (intended to be changed by you).
+    /// It also returns that newly displayed ShipLogFactListItem, that you would use to display any text you want (you could use the DisplayText method of the item for example).
+    /// </summary>
+    /// <returns></returns>
     public abstract ShipLogFactListItem DescriptionFieldGetNextItem();
+
+    /// <summary>
+    /// Returns the list of all ShipLogEntryListItem used to display the items in order from top to bottom.
+    /// All UI items are returned, including the ones that aren't currently used to display elements, and in fact 14 items are always returned even if the description field is used
+    /// (that only allows 7 items to be displayed at most), because the others items are never destroyed when creating the list (this detail isn't probably relevant to you but just in case).
+    /// </summary>
+    /// <returns></returns>
     public abstract List<ShipLogEntryListItem> GetItemsUI();
+
+    /// <summary>
+    /// Returns the index of the UI item used to display the item with the given index, or -1 if the item with index isn't currently displayed (because of scrolling). This could be combined with GetItemsUI.
+    /// For example, itemListWrapper.GetItemsUI()[itemListWrapper.GetIndexUI(itemListWrapper.GetSelectedIndex())] returns the ShipLogEntryListItem of the currently selected item.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
     public abstract int GetIndexUI(int index);
 }
 
@@ -109,11 +190,21 @@ public class ShipLogItemListWrapper : ItemListWrapper
         return _api.ItemListGetIndexUI(_itemList, index);
     }
 
+    /// <summary>
+    /// Makes the "Mark on HUD" rectangle object active or inactive depending on the parameter (this object starts disabled by default).
+    /// This root includes the border, background and the screen prompts that are displayed in the lower part of the photo or question mark square (and so it could cover part of the photo),
+    /// all these elements are made visible or invsible using this method.
+    /// </summary>
+    /// <param name="enable"></param>
     public void MarkHUDRootEnable(bool enable)
     {
         _api.ItemListMarkHUDRootEnable(_itemList, enable);
     }
 
+    /// <summary>
+    /// Returns the ScreenPromptList of the "Mark on HUD" rectangle, initially empty (no prompts), so you could add your prompts.
+    /// </summary>
+    /// <returns></returns>
     public ScreenPromptList MarkHUDGetPromptList()
     {
         return _api.ItemListMarkHUDGetPromptList(_itemList);


### PR DESCRIPTION
This implements the feature request from #35 

The custom modes for the ship log only used standard item lists, so they could be ported to Suit Log without any hassle. I only had to follow the advice from the Suit Log mod (using the generic ItemListWrapper from the Ship Log Slide Reel Player Plus mod).

The second commit fixes an issue where the images for the check list wouldn't load (defaulting to the OTHER_SYSTEM_PLACEHOLDER) unless the ship log was accessed first. It turns out there was a much nicer way to fetch the sprites than by traversing the component hierarchy, and that solves my issue as well.

Scrolling through the inventory throws the following exception, but it doesn't seem to have any ill effect. Not sure if it's my fault, Suit Log's fault, or something else.
```
NullReferenceException: Object reference not set to an instance of an object
Stacktrace: ShipLogFactListItem.GetPosition () (at <bb45013cdd174c6e9670b07181b0b751>:0)
SuitLog.DescriptionField.GetListBottomPos () (at <3950c138613545e99c60c4ac7de16658>:0)
SuitLog.DescriptionField.GetMaxScroll () (at <3950c138613545e99c60c4ac7de16658>:0)
SuitLog.DescriptionField.UpdateScroll () (at <3950c138613545e99c60c4ac7de16658>:0)
SuitLog.DescriptionField.Update () (at <3950c138613545e99c60c4ac7de16658>:0)
```