### PR TITLE
Added warp path logic to BHF

### DIFF
--- a/mod/InGameTracker/Logic.cs
+++ b/mod/InGameTracker/Logic.cs
@@ -62,7 +62,7 @@ public class Logic
         { SlotDataSpawn.Vanilla, "Timber Hearth Village" },
         { SlotDataSpawn.HourglassTwins, "Hourglass Twins" },
         { SlotDataSpawn.TimberHearth, "Timber Hearth" },
-        { SlotDataSpawn.BrittleHollow, "Brittle Hollow" },
+        { SlotDataSpawn.BrittleHollow, "Brittle Hollow Northern Glacier" },
         { SlotDataSpawn.GiantsDeep, "Giant's Deep" },
         { SlotDataSpawn.Stranger, "Stranger Sunside Hangar" },
     };
@@ -76,7 +76,7 @@ public class Logic
         { "ATT", "Hourglass Twins" },
         { "TH", "Timber Hearth" },
         { "THT", "Hourglass Twins" },
-        { "BHNG", "Brittle Hollow" },
+        { "BHNG", "Brittle Hollow Northern Glacier" },
         { "WHS", "White Hole Station" },
         { "BHF", "Hanging City Ceiling" },
         { "BHT", "Hourglass Twins" },


### PR DESCRIPTION
Related PR: [Ixrec/Archipelago#7](https://github.com/Ixrec/Archipelago/pull/7)

Changes the in-game tracker logic to send the BHNG warp and BH spawn to the new "Brittle Hollow Northern Glacier" region to reflect the changes made in the above PR.