### PR TITLE
Fix suit log with vanilla coordinates

### DIFF
--- a/mod/ItemImpls/OtherBaseGameProgression/Coordinates.cs
+++ b/mod/ItemImpls/OtherBaseGameProgression/Coordinates.cs
@@ -114,7 +114,15 @@ public static class Coordinates
     {
         // just recreate it every time we enter ship or suit log to be safe
         // some ship log views will stretch this sprite into a square, so we need to draw a square (600 x 600) to avoid distortion
-        shipLogCoordsSprite = CoordinateDrawing.CreateCoordinatesSprite(shipLogCoordsTexture, correctCoordinates, UnityEngine.Color.black, doKerning: false);
+        if (correctCoordinates != null)
+        {
+            shipLogCoordsSprite = CoordinateDrawing.CreateCoordinatesSprite(
+                shipLogCoordsTexture,
+                correctCoordinates,
+                UnityEngine.Color.black,
+                doKerning: false
+            );
+        }
     }
 
     public static void EnsureShipLogPTMEntrySpriteEdited()

--- a/mod/ItemImpls/OtherBaseGameProgression/Coordinates.cs
+++ b/mod/ItemImpls/OtherBaseGameProgression/Coordinates.cs
@@ -137,7 +137,8 @@ public static class Coordinates
             if (_hasCoordinates)
             {
                 EnsureShipLogCoordsSpriteCreated();
-                ptmGeneratedEntry?.SetAltSprite(shipLogCoordsSprite);
+                if (shipLogCoordsSprite != null)
+                    ptmGeneratedEntry?.SetAltSprite(shipLogCoordsSprite);
             }
             else
             {


### PR DESCRIPTION
When initializing, the suit log called EnsureShipLogCoordsSpriteCreated, which didn't check if the coordinates were vanilla before trying to draw them. This led to an exception that probably left the suit log in a weird state. Trying to open and close the suit log would then lead to a softlock.