### PR TITLE
Outer Wilds: Additional Trap Items

### DIFF
--- a/mod/InGameTracker/APInventoryMode.cs
+++ b/mod/InGameTracker/APInventoryMode.cs
@@ -100,6 +100,7 @@ public class APInventoryMode : ShipLogMode
         new InventoryItemEntry(Item.MapDisableTrap, "Map Disable Trap"),
         new InventoryItemEntry(Item.HUDCorruptionTrap, "HUD Corruption Trap"),
         new InventoryItemEntry(Item.IcePhysicsTrap, "Ice Physics Trap"),
+        new InventoryItemEntry(Item.SupernovaTrap, "Supernova Trap"),
     };
 
     // The ID being both the key and the the first value in the InventoryItemEntry is intentional redundancy in the public API for cleaner client code

--- a/mod/InGameTracker/APInventoryMode.cs
+++ b/mod/InGameTracker/APInventoryMode.cs
@@ -96,6 +96,9 @@ public class APInventoryMode : ShipLogMode
         new InventoryItemEntry(Item.ShipDamageTrap, "Ship Damage Trap"),
         new InventoryItemEntry(Item.AudioTrap, "Audio Trap"),
         new InventoryItemEntry(Item.NapTrap, "Nap Trap"),
+        new InventoryItemEntry(Item.SuitPunctureTrap, "Suit Puncture Trap"),
+        new InventoryItemEntry(Item.MapDisableTrap, "Map Disable Trap"),
+        new InventoryItemEntry(Item.HUDCorruptionTrap, "HUD Corruption Trap"),
     };
 
     // The ID being both the key and the the first value in the InventoryItemEntry is intentional redundancy in the public API for cleaner client code

--- a/mod/InGameTracker/APInventoryMode.cs
+++ b/mod/InGameTracker/APInventoryMode.cs
@@ -99,6 +99,7 @@ public class APInventoryMode : ShipLogMode
         new InventoryItemEntry(Item.SuitPunctureTrap, "Suit Puncture Trap"),
         new InventoryItemEntry(Item.MapDisableTrap, "Map Disable Trap"),
         new InventoryItemEntry(Item.HUDCorruptionTrap, "HUD Corruption Trap"),
+        new InventoryItemEntry(Item.IcePhysicsTrap, "Ice Physics Trap"),
     };
 
     // The ID being both the key and the the first value in the InventoryItemEntry is intentional redundancy in the public API for cleaner client code

--- a/mod/Item.cs
+++ b/mod/Item.cs
@@ -72,6 +72,7 @@ public enum Item
     SuitPunctureTrap,
     MapDisableTrap,
     HUDCorruptionTrap,
+    IcePhysicsTrap,
     // end of non-unique items
 
     FrequencyDSR,
@@ -190,6 +191,7 @@ public static class ItemNames
         { Item.SuitPunctureTrap, "Suit Puncture Trap" },
         { Item.MapDisableTrap, "Map Disable Trap" },
         { Item.HUDCorruptionTrap, "HUD Corruption Trap" },
+        { Item.IcePhysicsTrap, "Ice Physics Trap" },
 
         { Item.FrequencyDSR, "Deep Space Radio Frequency" },
         { Item.SignalDSRTower, "Radio Tower Signal" },

--- a/mod/Item.cs
+++ b/mod/Item.cs
@@ -69,6 +69,7 @@ public enum Item
     ShipDamageTrap,
     AudioTrap,
     NapTrap,
+    SuitPunctureTrap,
     // end of non-unique items
 
     FrequencyDSR,
@@ -184,6 +185,7 @@ public static class ItemNames
         { Item.ShipDamageTrap, "Ship Damage Trap" },
         { Item.AudioTrap, "Audio Trap" },
         { Item.NapTrap, "Nap Trap" },
+        { Item.SuitPunctureTrap, "Suit Puncture Trap" },
 
         { Item.FrequencyDSR, "Deep Space Radio Frequency" },
         { Item.SignalDSRTower, "Radio Tower Signal" },

--- a/mod/Item.cs
+++ b/mod/Item.cs
@@ -73,6 +73,7 @@ public enum Item
     MapDisableTrap,
     HUDCorruptionTrap,
     IcePhysicsTrap,
+    SupernovaTrap,
     // end of non-unique items
 
     FrequencyDSR,
@@ -192,6 +193,7 @@ public static class ItemNames
         { Item.MapDisableTrap, "Map Disable Trap" },
         { Item.HUDCorruptionTrap, "HUD Corruption Trap" },
         { Item.IcePhysicsTrap, "Ice Physics Trap" },
+        { Item.SupernovaTrap, "Supernova Trap" },
 
         { Item.FrequencyDSR, "Deep Space Radio Frequency" },
         { Item.SignalDSRTower, "Radio Tower Signal" },

--- a/mod/Item.cs
+++ b/mod/Item.cs
@@ -70,6 +70,7 @@ public enum Item
     AudioTrap,
     NapTrap,
     SuitPunctureTrap,
+    MapDisableTrap,
     // end of non-unique items
 
     FrequencyDSR,
@@ -186,6 +187,7 @@ public static class ItemNames
         { Item.AudioTrap, "Audio Trap" },
         { Item.NapTrap, "Nap Trap" },
         { Item.SuitPunctureTrap, "Suit Puncture Trap" },
+        { Item.MapDisableTrap, "Map Disable Trap" },
 
         { Item.FrequencyDSR, "Deep Space Radio Frequency" },
         { Item.SignalDSRTower, "Radio Tower Signal" },

--- a/mod/Item.cs
+++ b/mod/Item.cs
@@ -71,6 +71,7 @@ public enum Item
     NapTrap,
     SuitPunctureTrap,
     MapDisableTrap,
+    HUDCorruptionTrap,
     // end of non-unique items
 
     FrequencyDSR,
@@ -188,6 +189,7 @@ public static class ItemNames
         { Item.NapTrap, "Nap Trap" },
         { Item.SuitPunctureTrap, "Suit Puncture Trap" },
         { Item.MapDisableTrap, "Map Disable Trap" },
+        { Item.HUDCorruptionTrap, "HUD Corruption Trap" },
 
         { Item.FrequencyDSR, "Deep Space Radio Frequency" },
         { Item.SignalDSRTower, "Radio Tower Signal" },

--- a/mod/ItemImpls/FillerAndTrap/HUDCorruptionTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/HUDCorruptionTrap.cs
@@ -25,15 +25,18 @@ namespace ArchipelagoRandomizer
 
         static void CorruptPlayerHUD()
         {
+            //ignore if we're on menus or in credits
             if (LoadManager.GetCurrentScene() != OWScene.SolarSystem && LoadManager.GetCurrentScene() != OWScene.EyeOfTheUniverse)
                 return;
 
+            //no sense in corrupting a HUD the player can't see. Ignoring further corruptions if one is already active as well
             if (corruptionComponent != null || !PlayerState.IsWearingSuit())
                 return;
 
             corruptionComponent = Locator.GetPlayerTransform().gameObject.AddComponent<HUDCorruptionComponent>();
         }
 
+        //HUD Helmet animator is the component responsible for how the HUD animates (aberration, flickering, etc)
         private static HUDHelmetAnimator helmetAnimator = null;
 
         [HarmonyPrefix, HarmonyPatch(typeof(HUDHelmetAnimator), nameof(HUDHelmetAnimator.Awake))]
@@ -41,11 +44,11 @@ namespace ArchipelagoRandomizer
 
         class HUDCorruptionComponent : MonoBehaviour
         {
+            //length of the HUD corruption, in seconds
             float corruptionDuration = 10.0f;
 
             void Start()
             {
-                APRandomizer.OWMLModConsole.WriteLine("Corrupting HUD");
                 var nd = new NotificationData(NotificationTarget.Player, "HUD MALFUNCTION. RECALIBRATING.", corruptionDuration);
                 NotificationManager.SharedInstance.PostNotification(nd);
             }
@@ -54,8 +57,8 @@ namespace ArchipelagoRandomizer
             {
                 if (corruptionDuration > 0)
                 {
-                    helmetAnimator._hudDamageWobble = Mathf.PerlinNoise(Time.timeSinceLevelLoad, 0f) * 0.3f;
-                    helmetAnimator._hudTimer = Mathf.PerlinNoise(Time.timeSinceLevelLoad, 1f);
+                    helmetAnimator._hudDamageWobble = Mathf.PerlinNoise(Time.timeSinceLevelLoad, 0f) * 0.3f; //responsible for the chromatic aberration. Higher value = more erratic
+                    helmetAnimator._hudTimer = Mathf.PerlinNoise(Time.timeSinceLevelLoad, 1f); //responsible for the flickering. Fluctuates randomly between 0 and 1
                     corruptionDuration -= Time.deltaTime;
                 }
                 else

--- a/mod/ItemImpls/FillerAndTrap/HUDCorruptionTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/HUDCorruptionTrap.cs
@@ -1,0 +1,68 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace ArchipelagoRandomizer
+{
+    [HarmonyPatch]
+    internal class HUDCorruptionTrap
+    {
+        private static uint _hudCorruptionTraps;
+
+        public static uint hudCorruptionTraps
+        {
+            get => _hudCorruptionTraps;
+            set
+            {
+                if (value > _hudCorruptionTraps)
+                {
+                    CorruptPlayerHUD();
+                }
+                _hudCorruptionTraps = value;
+            }
+        }
+
+        private static HUDCorruptionComponent corruptionComponent = null;
+
+        static void CorruptPlayerHUD()
+        {
+            if (LoadManager.GetCurrentScene() != OWScene.SolarSystem && LoadManager.GetCurrentScene() != OWScene.EyeOfTheUniverse)
+                return;
+
+            if (corruptionComponent != null || !PlayerState.IsWearingSuit())
+                return;
+
+            corruptionComponent = Locator.GetPlayerTransform().gameObject.AddComponent<HUDCorruptionComponent>();
+        }
+
+        private static HUDHelmetAnimator helmetAnimator = null;
+
+        [HarmonyPrefix, HarmonyPatch(typeof(HUDHelmetAnimator), nameof(HUDHelmetAnimator.Awake))]
+        public static void HUDHelmetAnimator_Awake(HUDHelmetAnimator __instance) => helmetAnimator = __instance;
+
+        class HUDCorruptionComponent : MonoBehaviour
+        {
+            float corruptionDuration = 10.0f;
+
+            void Start()
+            {
+                APRandomizer.OWMLModConsole.WriteLine("Corrupting HUD");
+                var nd = new NotificationData(NotificationTarget.Player, "HUD MALFUNCTION. RECALIBRATING.", corruptionDuration);
+                NotificationManager.SharedInstance.PostNotification(nd);
+            }
+
+            void Update()
+            {
+                if (corruptionDuration > 0)
+                {
+                    helmetAnimator._hudDamageWobble = Mathf.PerlinNoise(Time.timeSinceLevelLoad, 0f) * 0.3f;
+                    helmetAnimator._hudTimer = Mathf.PerlinNoise(Time.timeSinceLevelLoad, 1f);
+                    corruptionDuration -= Time.deltaTime;
+                }
+                else
+                {
+                    gameObject.DestroyAllComponents<HUDCorruptionComponent>();
+                }
+            }
+        }
+    }
+}

--- a/mod/ItemImpls/FillerAndTrap/IcePhysicsTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/IcePhysicsTrap.cs
@@ -21,9 +21,11 @@ namespace ArchipelagoRandomizer
 
         private static void ApplyIcePhysics()
         {
+            //we're in credits or menus. Ignore.
             if (LoadManager.GetCurrentScene() != OWScene.SolarSystem && LoadManager.GetCurrentScene() != OWScene.EyeOfTheUniverse)
                 return;
 
+            //this call is necessary, otherwise the player is stuck in place and has to jump to have ice physics applied
             characterController.MakeUngrounded();
             icePhysicsApplied = true;
         }
@@ -36,9 +38,11 @@ namespace ArchipelagoRandomizer
         private static void PlayerCharacterController_Awake(PlayerCharacterController __instance)
         {
             characterController = __instance;
-            icePhysicsApplied = false;
+            icePhysicsApplied = false; //resetting this to avoid ice physics carrying over in the next loop
         }
 
+        //CastForGrounded sets the collider and surface type the player is standing on.
+        //using a postfix to override that if we have ice physics applied for the duration of the loop
         [HarmonyPostfix, HarmonyPatch(typeof(PlayerCharacterController), nameof(PlayerCharacterController.CastForGrounded))]
         private static void PlayerCharacterController_CastForGrounded_Postfix()
         {

--- a/mod/ItemImpls/FillerAndTrap/IcePhysicsTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/IcePhysicsTrap.cs
@@ -1,0 +1,52 @@
+﻿using HarmonyLib;
+namespace ArchipelagoRandomizer
+{
+    [HarmonyPatch]
+    internal class IcePhysicsTrap
+    {
+        private static uint _icePhysicsTraps;
+
+        public static uint icePhysicsTraps
+        {
+            get => _icePhysicsTraps;
+            set
+            {
+                if (value > _icePhysicsTraps)
+                {
+                    ApplyIcePhysics();
+                }
+                _icePhysicsTraps = value;
+            }
+        }
+
+        private static void ApplyIcePhysics()
+        {
+            if (LoadManager.GetCurrentScene() != OWScene.SolarSystem && LoadManager.GetCurrentScene() != OWScene.EyeOfTheUniverse)
+                return;
+
+            characterController.MakeUngrounded();
+            icePhysicsApplied = true;
+        }
+
+        private static bool icePhysicsApplied;
+
+        private static PlayerCharacterController characterController = null;
+
+        [HarmonyPrefix, HarmonyPatch(typeof(PlayerCharacterController), nameof(PlayerCharacterController.Awake))]
+        private static void PlayerCharacterController_Awake(PlayerCharacterController __instance)
+        {
+            characterController = __instance;
+            icePhysicsApplied = false;
+        }
+
+        [HarmonyPostfix, HarmonyPatch(typeof(PlayerCharacterController), nameof(PlayerCharacterController.CastForGrounded))]
+        private static void PlayerCharacterController_CastForGrounded_Postfix()
+        {
+            if (!icePhysicsApplied)
+                return;
+
+            characterController._groundCollider.material.dynamicFriction = 0.0f;
+            characterController._groundSurface = SurfaceType.Ice;
+        }
+    }
+}

--- a/mod/ItemImpls/FillerAndTrap/MapDisableTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/MapDisableTrap.cs
@@ -1,0 +1,31 @@
+﻿using HarmonyLib;
+
+namespace ArchipelagoRandomizer
+{
+    [HarmonyPatch]
+    internal class MapDisableTrap
+    {
+        private static uint _mapDisableTraps;
+
+        public static uint mapDisableTraps
+        {
+            get => _mapDisableTraps;
+            set
+            {
+                if (value > _mapDisableTraps)
+                {
+                    DisableMap();
+                }
+                _mapDisableTraps = value;
+            }
+        }
+
+        static void DisableMap()
+        {
+            if (LoadManager.GetCurrentScene() != OWScene.SolarSystem && LoadManager.GetCurrentScene() != OWScene.EyeOfTheUniverse)
+                return;
+
+            GlobalMessenger.FireEvent("BrokeMapSatellite");
+        }
+    }
+}

--- a/mod/ItemImpls/FillerAndTrap/MapDisableTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/MapDisableTrap.cs
@@ -22,9 +22,11 @@ namespace ArchipelagoRandomizer
 
         static void DisableMap()
         {
-            if (LoadManager.GetCurrentScene() != OWScene.SolarSystem && LoadManager.GetCurrentScene() != OWScene.EyeOfTheUniverse)
+            //only applicable in the solar system
+            if (LoadManager.GetCurrentScene() != OWScene.SolarSystem)
                 return;
 
+            //simulate the "crashing into the Deep Space Satellite" event by just firing it
             GlobalMessenger.FireEvent("BrokeMapSatellite");
         }
     }

--- a/mod/ItemImpls/FillerAndTrap/SuitPunctureTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/SuitPunctureTrap.cs
@@ -5,7 +5,7 @@ namespace ArchipelagoRandomizer
     [HarmonyPatch]
     internal class SuitPunctureTrap
     {
-        public static uint _suitPunctureTraps;
+        private static uint _suitPunctureTraps;
 
         public static uint suitPunctureTraps
         {

--- a/mod/ItemImpls/FillerAndTrap/SuitPunctureTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/SuitPunctureTrap.cs
@@ -29,7 +29,8 @@ namespace ArchipelagoRandomizer
             playerResources.ApplySuitPuncture();
 
             //if the player is not wearing the suit (rare unless playing suitless) the oxygen leak sound
-            //will still play. In order for it to not get annoying, we disable it
+            //will still play. In order for it to not get annoying, we disable it.
+            //Upon wearing the suit next, it would have holes in it
             if (!PlayerState.IsWearingSuit())
             {
                 playerResources._playerAudioController.UpdateSuitPunctures(0, PlayerResources._maxSuitPunctures);

--- a/mod/ItemImpls/FillerAndTrap/SuitPunctureTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/SuitPunctureTrap.cs
@@ -1,0 +1,44 @@
+﻿using HarmonyLib;
+
+namespace ArchipelagoRandomizer
+{
+    [HarmonyPatch]
+    internal class SuitPunctureTrap
+    {
+        public static uint _suitPunctureTraps;
+
+        public static uint suitPunctureTraps
+        {
+            get => _suitPunctureTraps;
+            set
+            {
+                if (value > _suitPunctureTraps)
+                {
+                    PunctureSuit();
+                }
+                _suitPunctureTraps = value;
+            }
+        }
+
+        static void PunctureSuit()
+        {
+            //we're not in gameplay, ignore
+            if (LoadManager.GetCurrentScene() != OWScene.SolarSystem && LoadManager.GetCurrentScene() != OWScene.EyeOfTheUniverse)
+                return;
+
+            playerResources.ApplySuitPuncture();
+
+            //if the player is not wearing the suit (rare unless playing suitless) the oxygen leak sound
+            //will still play. In order for it to not get annoying, we disable it
+            if (!PlayerState.IsWearingSuit())
+            {
+                playerResources._playerAudioController.UpdateSuitPunctures(0, PlayerResources._maxSuitPunctures);
+            }
+        }
+
+        static PlayerResources playerResources = null;
+
+        [HarmonyPrefix, HarmonyPatch(typeof(PlayerResources), nameof(PlayerResources.Awake))]
+        public static void PlayerResources_Awake(PlayerResources __instance) => playerResources = __instance;
+    }
+}

--- a/mod/ItemImpls/FillerAndTrap/SupernovaTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/SupernovaTrap.cs
@@ -24,7 +24,8 @@ namespace ArchipelagoRandomizer
 
         private static void TriggerSupernova()
         {
-            if (LoadManager.GetCurrentScene() != OWScene.SolarSystem && LoadManager.GetCurrentScene() != OWScene.EyeOfTheUniverse)
+            //trigger ONLY in the main solar system scene. Supernova while reaching the eye is not a good idea
+            if (LoadManager.GetCurrentScene() != OWScene.SolarSystem)
                 return;
 
             if (triggeredSupernovaInThisLoop)

--- a/mod/ItemImpls/FillerAndTrap/SupernovaTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/SupernovaTrap.cs
@@ -1,0 +1,40 @@
+﻿using HarmonyLib;
+
+namespace ArchipelagoRandomizer
+{
+    [HarmonyPatch]
+    internal class SupernovaTrap
+    {
+        private static uint _supernovaTraps;
+
+        public static uint supernovaTraps
+        {
+            get => _supernovaTraps;
+            set
+            {
+                if (value > _supernovaTraps)
+                {
+                    TriggerSupernova();
+                }
+                _supernovaTraps = value;
+            }
+        }
+
+        private static bool triggeredSupernovaInThisLoop = false;
+
+        private static void TriggerSupernova()
+        {
+            if (LoadManager.GetCurrentScene() != OWScene.SolarSystem && LoadManager.GetCurrentScene() != OWScene.EyeOfTheUniverse)
+                return;
+
+            if (triggeredSupernovaInThisLoop)
+                return;
+
+            triggeredSupernovaInThisLoop = true;
+            GlobalMessenger.FireEvent("TriggerSupernova");
+        }
+
+        [HarmonyPrefix, HarmonyPatch(typeof(TimeLoop), nameof(TimeLoop.Start))]
+        private static void TimeLoop_Start_Prefix() => triggeredSupernovaInThisLoop = false;
+    }
+}

--- a/mod/ItemImpls/FillerAndTrap/SupernovaTrap.cs
+++ b/mod/ItemImpls/FillerAndTrap/SupernovaTrap.cs
@@ -28,14 +28,15 @@ namespace ArchipelagoRandomizer
             if (LoadManager.GetCurrentScene() != OWScene.SolarSystem)
                 return;
 
-            if (triggeredSupernovaInThisLoop)
+            //prevents triggering twice if a supernova is already in progress- whether by this trap of by the timeloop
+            if (triggeredSupernovaInThisLoop || TimeLoop.GetSecondsRemaining() <= 0.0)
                 return;
 
             triggeredSupernovaInThisLoop = true;
             GlobalMessenger.FireEvent("TriggerSupernova");
         }
 
-        [HarmonyPrefix, HarmonyPatch(typeof(TimeLoop), nameof(TimeLoop.Start))]
-        private static void TimeLoop_Start_Prefix() => triggeredSupernovaInThisLoop = false;
+        [HarmonyPrefix, HarmonyPatch(typeof(TimeLoop), nameof(TimeLoop.Awake))]
+        private static void TimeLoop_Awake_Prefix() => triggeredSupernovaInThisLoop = false;
     }
 }

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -365,6 +365,7 @@ internal class LocationTriggers
             case Item.NapTrap: NapTrap.napTraps = count; break;
             case Item.SuitPunctureTrap: SuitPunctureTrap.suitPunctureTraps = count; break;
             case Item.MapDisableTrap: MapDisableTrap.mapDisableTraps = count; break;
+            case Item.HUDCorruptionTrap: HUDCorruptionTrap.hudCorruptionTraps = count; break;
             case Item.LightModulator: StrangerLightModulator.hasLightModulator = (count > 0); break;
             case Item.BreachOverrideCodes: StrangerDoorCodes.hasBreachOverrideCodes = (count > 0); break;
             case Item.RLPaintingCode: StrangerDoorCodes.hasRLPaintingCode = (count > 0); break;

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -366,6 +366,7 @@ internal class LocationTriggers
             case Item.SuitPunctureTrap: SuitPunctureTrap.suitPunctureTraps = count; break;
             case Item.MapDisableTrap: MapDisableTrap.mapDisableTraps = count; break;
             case Item.HUDCorruptionTrap: HUDCorruptionTrap.hudCorruptionTraps = count; break;
+            case Item.IcePhysicsTrap: IcePhysicsTrap.icePhysicsTraps = count; break;
             case Item.LightModulator: StrangerLightModulator.hasLightModulator = (count > 0); break;
             case Item.BreachOverrideCodes: StrangerDoorCodes.hasBreachOverrideCodes = (count > 0); break;
             case Item.RLPaintingCode: StrangerDoorCodes.hasRLPaintingCode = (count > 0); break;

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -367,6 +367,7 @@ internal class LocationTriggers
             case Item.MapDisableTrap: MapDisableTrap.mapDisableTraps = count; break;
             case Item.HUDCorruptionTrap: HUDCorruptionTrap.hudCorruptionTraps = count; break;
             case Item.IcePhysicsTrap: IcePhysicsTrap.icePhysicsTraps = count; break;
+            case Item.SupernovaTrap: SupernovaTrap.supernovaTraps = count; break;
             case Item.LightModulator: StrangerLightModulator.hasLightModulator = (count > 0); break;
             case Item.BreachOverrideCodes: StrangerDoorCodes.hasBreachOverrideCodes = (count > 0); break;
             case Item.RLPaintingCode: StrangerDoorCodes.hasRLPaintingCode = (count > 0); break;

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -363,6 +363,7 @@ internal class LocationTriggers
             case Item.ShipDamageTrap: ShipDamage.shipDamageTraps = count; break;
             case Item.AudioTrap: AudioTrap.audioTraps = count; break;
             case Item.NapTrap: NapTrap.napTraps = count; break;
+            case Item.SuitPunctureTrap: SuitPunctureTrap.suitPunctureTraps = count; break;
             case Item.LightModulator: StrangerLightModulator.hasLightModulator = (count > 0); break;
             case Item.BreachOverrideCodes: StrangerDoorCodes.hasBreachOverrideCodes = (count > 0); break;
             case Item.RLPaintingCode: StrangerDoorCodes.hasRLPaintingCode = (count > 0); break;

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -364,6 +364,7 @@ internal class LocationTriggers
             case Item.AudioTrap: AudioTrap.audioTraps = count; break;
             case Item.NapTrap: NapTrap.napTraps = count; break;
             case Item.SuitPunctureTrap: SuitPunctureTrap.suitPunctureTraps = count; break;
+            case Item.MapDisableTrap: MapDisableTrap.mapDisableTraps = count; break;
             case Item.LightModulator: StrangerLightModulator.hasLightModulator = (count > 0); break;
             case Item.BreachOverrideCodes: StrangerDoorCodes.hasBreachOverrideCodes = (count > 0); break;
             case Item.RLPaintingCode: StrangerDoorCodes.hasRLPaintingCode = (count > 0); break;


### PR DESCRIPTION
Created and tested the following trap items, as per issue#60 (plus one of my own):

- Ice Physics Trap
- HUD Corruption Trap
- Map Disable Trap
- Suit Puncture Trap
- Supernova Trap (idea of my own, in vein of traps that directly kill you)

Tested through generating seeds with an updated apworld (created a pull request for that as well) and running from source locally.
Traps are obtainable through checking locations and through being sent by the server (used the send command, emulating other players sending them)