### PR TITLE
Band-Aid fix for the recursive node issue

### DIFF
--- a/mod/ItemImpls/FCProgression/FixRecursiveNode.cs
+++ b/mod/ItemImpls/FCProgression/FixRecursiveNode.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using UnityEngine;
+
+namespace ArchipelagoRandomizer.ItemImpls.FCProgression
+{
+    class FixRecursiveNode
+    {
+        [HarmonyPostfix, HarmonyPatch(typeof(PlayerSectorDetector), nameof(PlayerSectorDetector.OnAddSector))]
+        public static void PlayerSectorDetector_OnAddSector(PlayerSectorDetector __instance, Sector sector)
+        {
+            if (sector._idString != "Briar's Hollow") return;
+            // For an unknown reason, the recursive node in Briar's Hollow is sometimes disabled. We forcibly re-enable it here
+            GameObject loopNode = GameObject.Find("BriarsHollow_Body/Sector/Loop Node");
+            loopNode.SetActive(true);
+        }
+    }
+}

--- a/mod/ItemImpls/FCProgression/FixRecursiveNode.cs
+++ b/mod/ItemImpls/FCProgression/FixRecursiveNode.cs
@@ -17,7 +17,11 @@ namespace ArchipelagoRandomizer.ItemImpls.FCProgression
             if (sector._idString != "Briar's Hollow") return;
             // For an unknown reason, the recursive node in Briar's Hollow is sometimes disabled. We forcibly re-enable it here
             GameObject loopNode = GameObject.Find("BriarsHollow_Body/Sector/Loop Node");
-            loopNode.SetActive(true);
+            if (!loopNode.activeSelf)
+            {
+                APRandomizer.OWMLModConsole.WriteLine($"PlayerSectorDetector_OnAddSector() Recursive mode disabled. Re-enabling", OWML.Common.MessageType.Warning);
+                loopNode.SetActive(true);
+            }
         }
     }
 }


### PR DESCRIPTION
Forcibly enables the recursive node when the player enters Briar's Hollow. Should fix #96 