### PR TITLE
fix thread-safety when processing AP actions/messages

### DIFF
--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -314,20 +314,24 @@ public class APRandomizer : ModBehaviour
 
     private static void APSession_ErrorReceived(Exception e, string message)
     {
-        if (!SocketWarningsAlreadyShown.Contains(message))
+        // writes to the console, so needs to run on the main thread
+        MainThreadDispatcher.Enqueue(() =>
         {
-            SocketWarningsAlreadyShown.Add(message);
+            if (!SocketWarningsAlreadyShown.Contains(message))
+            {
+                SocketWarningsAlreadyShown.Add(message);
 
-            APRandomizer.InGameAPConsole.AddText($"<color='orange'>Received an error from APSession.Socket. This means you may have lost connection to the AP server. " +
-                $"In order to safely reconnect to the AP server, we recommend quitting and resuming at your earliest convenience.</color>");
+                APRandomizer.InGameAPConsole.AddText($"<color='orange'>Received an error from APSession.Socket. This means you may have lost connection to the AP server. " +
+                    $"In order to safely reconnect to the AP server, we recommend quitting and resuming at your earliest convenience.</color>");
 
-            APRandomizer.OWMLModConsole.WriteLine(
-                $"Received error from APSession.Socket: '{message}'\n" +
-                $"(duplicates of this error will be silently ignored)\n" +
-                $"\n" +
-                $"{e.StackTrace}",
-                MessageType.Warning);
-        }
+                APRandomizer.OWMLModConsole.WriteLine(
+                    $"Received error from APSession.Socket: '{message}'\n" +
+                    $"(duplicates of this error will be silently ignored)\n" +
+                    $"\n" +
+                    $"{e.StackTrace}",
+                    MessageType.Warning);
+            }
+        });
     }
 
     // Here we move received item processing off the websocket thread because this is believed to help prevent crashes
@@ -350,6 +354,9 @@ public class APRandomizer : ModBehaviour
                 $"{ex.StackTrace}",
                 MessageType.Error);
         }
+
+        // Run scheduled actions that need to run on the main thread
+        MainThreadDispatcher.DrainOnMainThread();
 
         // Manually invoke Update() methods on any non-Component classes that also want to do the "wait until Update()" workaround
         DeathLinkManager.Update();
@@ -375,17 +382,21 @@ public class APRandomizer : ModBehaviour
     }
     private static void APSession_OnMessageReceived(LogMessage message)
     {
-        try
+        // writes to the console, so needs to run on the main thread
+        MainThreadDispatcher.Enqueue(() =>
         {
-            ArchConsoleManager.AddAPMessage(message);
-        }
-        catch (Exception ex)
-        {
-            APRandomizer.OWMLModConsole.WriteLine(
-                $"Caught error in APSession_OnMessageReceived: '{ex.Message}'\n" +
-                $"{ex.StackTrace}",
-                MessageType.Error);
-        }
+            try
+            {
+                ArchConsoleManager.AddAPMessage(message);
+            }
+            catch (Exception ex)
+            {
+                APRandomizer.OWMLModConsole.WriteLine(
+                    $"Caught error in APSession_OnMessageReceived: '{ex.Message}'\n" +
+                    $"{ex.StackTrace}",
+                    MessageType.Error);
+            }
+        });
     }
 
     private static bool SyncItemCountWithAPServer(long itemId)

--- a/mod/ArchConsoleManager.cs
+++ b/mod/ArchConsoleManager.cs
@@ -70,7 +70,9 @@ public class ArchConsoleManager : MonoBehaviour
 
         APRandomizer.OnSessionOpened += (s) =>
         {
-            s.Locations.CheckedLocationsUpdated += UpdateProgress;
+            // this ends up doing UI work and need to run on the main thread
+            s.Locations.CheckedLocationsUpdated += (checkedLocations) =>
+                MainThreadDispatcher.Enqueue(() => UpdateProgress(checkedLocations));
             session = s;
             APRandomizer.HasSeenSettingsText = false;
         };

--- a/mod/InGameTracker/TrackerManager.cs
+++ b/mod/InGameTracker/TrackerManager.cs
@@ -54,10 +54,14 @@ public class TrackerManager : MonoBehaviour
             session = s;
             logic.previouslyObtainedItems = s.Items.AllItemsReceived;
             logic.InitializeAccessibility();
-            s.Items.ItemReceived += logic.RecheckAccessibility;
-            s.Locations.CheckedLocationsUpdated += logic.CheckLocations;
+            // these end up doing UI work and need to run on the main thread
+            s.Items.ItemReceived += (helper) =>
+                MainThreadDispatcher.Enqueue(() => logic.RecheckAccessibility(helper));
+            s.Locations.CheckedLocationsUpdated += (checkedLocations) =>
+                MainThreadDispatcher.Enqueue(() => logic.CheckLocations(checkedLocations));
             logic.CheckLocations(s.Locations.AllLocationsChecked);
-            s.DataStorage.TrackHints(ReadHints);
+            s.DataStorage.TrackHints((hints) =>
+                MainThreadDispatcher.Enqueue(() => ReadHints(hints)));
         };
         APRandomizer.OnSessionClosed += (s, m) =>
         {

--- a/mod/MainThreadDispatcher.cs
+++ b/mod/MainThreadDispatcher.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Concurrent;
+using OWML.Common;
+
+namespace ArchipelagoRandomizer;
+
+/// <summary>
+/// Delegate work from threads to the Unity main thread. Work is executed during APRandomizer.Update().
+/// To be used when tasks need to happen on the main thread (e.g. UI updates).
+/// </summary>
+public static class MainThreadDispatcher
+{
+    private static readonly ConcurrentQueue<Action> queue = new();
+
+    /// <summary>
+    /// Queues an action to run on the Unity main thread during the next APRandomizer.Update().
+    /// Safe to call from any thread.
+    /// </summary>
+    public static void Enqueue(Action action)
+    {
+        if (action != null)
+            queue.Enqueue(action);
+    }
+
+    /// <summary>
+    /// Runs the queued actions.
+    /// Must be called from main thread.
+    /// </summary>
+    public static void DrainOnMainThread()
+    {
+        // We only run as many tasks as there were when we entered this method to prevent starvation in case
+        // we are spammed with actions.
+        int budget = queue.Count;
+        while (budget-- > 0 && queue.TryDequeue(out var action))
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                APRandomizer.OWMLModConsole.WriteLine(
+                    $"MainThreadDispatcher action threw an exception: {ex.Message}\n{ex.StackTrace}",
+                    MessageType.Error);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a new static class to dispatch actions that touch the unity UI (and other potentially not thread-safe things) to the main thread in the mod's AP update loop. I hooked into a few places related to displaying messages in the console.

This fixes UI corruptions and other bugs caused by memory corruption. Not sure if this fixes ALL issues people reported, there are probably some places I missed.

Could probably be generalized in the future with other existing solutions to this problem (the one for death links) but that looked a bit more complicated so I didn't bother doing that for now.

### Note
I have not yet done a full run with this. I did basic testing by unlocking things from outside the game and a general "stress test" by spamming console messages with/without this fix to confirm the issue.
I have not tested messages related to hints or accessibility, but see no reason it wouldn't work.

I'll only fully test this after I fixed other issues related to NomaiVR compatibility.

### AI Disclosure
I'm not a .NET dev and have barely worked with Unity/Harmony before. I used Claude Code to troubleshoot the issue (after I analysed it might be thread related). It also generated the code, I just touched it a up a bit (it's not really a big change after all). I can't fully determine if this is the best/correct way to do or if there are any gaps, but it all seems sensible & logical to me. I wrote this PR description, commit messages etc. myself and tested the changes, I also understand and "own" the code in this PR.
