### PR TITLE
NomaiVR compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Outer Wilds story mods whose content has been fully integrated into this randomi
 Outer Wilds quality of life/tooling/etc mods that this randomizer goes out of its way to support:
 
 - Suit Log: All of the ship log's "in-game tracker" content is available in the Suit Log too.
+- NomaiVR: The randomizer has explicit support for the mod, such as to disable/enable tools correctly and to make interacting with the console possible (with some caveats such as the scrollbar being buggy). The mod may not support all possible interactions fully, some traps (such as the HUD Corruption Trap) also do not work. Story mods + VR are untested.
 
 Outer Wilds quality of life/tooling/etc mods that are known to work without issue:
 
@@ -139,7 +140,6 @@ Outer Wilds quality of life/tooling/etc mods that are known to work without issu
 Outer Wilds mods that have been tried, but are known to have issues (this information might not be kept up to date, as I don't/can't test these myself):
 
 - Time Saver (thanks Jade and toasty for testing this): mostly works, but you must leave the "Always Start With Suit" option disabled.
-- NomaiVR (thanks Snout for testing this): Mostly works. Trying to grab the Translator or Signalscope *before donning the suit* will softlock, but this is fine once you're in the suit. The in-game console does not work reliably, so using the AP Text Client instead is recommended.
 - Quantum Space Buddies: Awkward but can *probably* be made to work. I believe you would have to use one of the "... Random Expedition" main menu buttons to connect to your AP server, immediately quit back to the main menu, then use either of QSB's main menu buttons to load the game with multiplayer. Please tell us if you can test this properly.
 
 ## Contributing Features, Bugfixes, More Story Mods, etc

--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -314,20 +314,24 @@ public class APRandomizer : ModBehaviour
 
     private static void APSession_ErrorReceived(Exception e, string message)
     {
-        if (!SocketWarningsAlreadyShown.Contains(message))
+        // writes to the console, so needs to run on the main thread
+        MainThreadDispatcher.Enqueue(() =>
         {
-            SocketWarningsAlreadyShown.Add(message);
+            if (!SocketWarningsAlreadyShown.Contains(message))
+            {
+                SocketWarningsAlreadyShown.Add(message);
 
-            APRandomizer.InGameAPConsole.AddText($"<color='orange'>Received an error from APSession.Socket. This means you may have lost connection to the AP server. " +
-                $"In order to safely reconnect to the AP server, we recommend quitting and resuming at your earliest convenience.</color>");
+                APRandomizer.InGameAPConsole.AddText($"<color='orange'>Received an error from APSession.Socket. This means you may have lost connection to the AP server. " +
+                    $"In order to safely reconnect to the AP server, we recommend quitting and resuming at your earliest convenience.</color>");
 
-            APRandomizer.OWMLModConsole.WriteLine(
-                $"Received error from APSession.Socket: '{message}'\n" +
-                $"(duplicates of this error will be silently ignored)\n" +
-                $"\n" +
-                $"{e.StackTrace}",
-                MessageType.Warning);
-        }
+                APRandomizer.OWMLModConsole.WriteLine(
+                    $"Received error from APSession.Socket: '{message}'\n" +
+                    $"(duplicates of this error will be silently ignored)\n" +
+                    $"\n" +
+                    $"{e.StackTrace}",
+                    MessageType.Warning);
+            }
+        });
     }
 
     // Here we move received item processing off the websocket thread because this is believed to help prevent crashes
@@ -350,6 +354,9 @@ public class APRandomizer : ModBehaviour
                 $"{ex.StackTrace}",
                 MessageType.Error);
         }
+
+        // Run scheduled actions that need to run on the main thread
+        MainThreadDispatcher.DrainOnMainThread();
 
         // Manually invoke Update() methods on any non-Component classes that also want to do the "wait until Update()" workaround
         DeathLinkManager.Update();
@@ -375,17 +382,21 @@ public class APRandomizer : ModBehaviour
     }
     private static void APSession_OnMessageReceived(LogMessage message)
     {
-        try
+        // writes to the console, so needs to run on the main thread
+        MainThreadDispatcher.Enqueue(() =>
         {
-            ArchConsoleManager.AddAPMessage(message);
-        }
-        catch (Exception ex)
-        {
-            APRandomizer.OWMLModConsole.WriteLine(
-                $"Caught error in APSession_OnMessageReceived: '{ex.Message}'\n" +
-                $"{ex.StackTrace}",
-                MessageType.Error);
-        }
+            try
+            {
+                ArchConsoleManager.AddAPMessage(message);
+            }
+            catch (Exception ex)
+            {
+                APRandomizer.OWMLModConsole.WriteLine(
+                    $"Caught error in APSession_OnMessageReceived: '{ex.Message}'\n" +
+                    $"{ex.StackTrace}",
+                    MessageType.Error);
+            }
+        });
     }
 
     private static bool SyncItemCountWithAPServer(long itemId)

--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -511,11 +511,14 @@ public class APRandomizer : ModBehaviour
             ExpandedDictionary.OnCompleteSceneLoad();
         };
 
-        // update the Nomai text setting before any can be created
         LoadManager.OnStartSceneLoad += (scene, loadScene) =>
         {
+            // update the Nomai text setting before any can be created
             NomaiTextQoL.NomaiTextQoL.AutoNomaiText = AutoNomaiText;
             NomaiTextQoL.NomaiTextQoL.ColorNomaiText = ColorNomaiText;
+
+            // install the NomaiVR spawn-facing suppression before the scene's objects Awake
+            Compatibility.NomaiVR.VRSpawnFacing.EnsurePatches();
         };
 
         SetupSaveData();

--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -40,6 +40,12 @@ public class APRandomizerSaveData
 public class APRandomizer : ModBehaviour
 {
     public static APRandomizer Instance;
+    
+    /// <summary>
+    /// If enabled items are only applied to the player via the `!debug` console command
+    /// (they aren't even loaded from save).
+    /// </summary>
+    public const bool UnlockItemsViaDebugOnly = false;
 
     public static APRandomizerSaveData SaveData;
     public static AssetBundle Assets;
@@ -151,8 +157,11 @@ public class APRandomizer : ModBehaviour
                 OWMLModConsole.WriteLine($"Existing save file loaded. You've checked {SaveData.locationsChecked.Where(kv => kv.Value).Count()} out of {SaveData.locationsChecked.Count} locations " +
                     $"and acquired one or more of {SaveData.itemsAcquired.Where(kv => kv.Value > 0).Count()} different item types out of {SaveData.itemsAcquired.Count} total types.");
 
-                foreach (var kv in SaveData.itemsAcquired)
-                    LocationTriggers.ApplyItemToPlayer(kv.Key, kv.Value);
+                if (!UnlockItemsViaDebugOnly)
+                {
+                    foreach (var kv in SaveData.itemsAcquired)
+                        LocationTriggers.ApplyItemToPlayer(kv.Key, kv.Value);
+                }
 
                 if (MainMenu.ResumeRandomExpeditionGO != null)
                 {
@@ -431,7 +440,8 @@ public class APRandomizer : ModBehaviour
         {
             APInventoryMode.MarkItemAsNew(item);
             APRandomizer.SaveData.itemsAcquired[item] = (uint)itemCountSoFar;
-            LocationTriggers.ApplyItemToPlayer(item, APRandomizer.SaveData.itemsAcquired[item], true);
+            if (!UnlockItemsViaDebugOnly)
+                LocationTriggers.ApplyItemToPlayer(item, APRandomizer.SaveData.itemsAcquired[item], true);
 
             // SetPersistentCondition() is not safe to call on the main menu because e.g. it can lead to Switch Profile mistakently copying save data onto other profiles,
             if (LoadManager.GetCurrentScene() != OWScene.TitleScreen)

--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -87,6 +87,7 @@ public class APRandomizer : ModBehaviour
     public static bool ColorNomaiText = true;
     public static bool InstantTranslator = false;
     public static bool HasSeenSettingsText = false;
+    public static bool UnlockNotification = false;
 
     // Throttle save file writes to once per second to avoid IOExceptions for conflicting write attempts
     private static Task pendingSaveFileWrite = null;
@@ -430,7 +431,7 @@ public class APRandomizer : ModBehaviour
         {
             APInventoryMode.MarkItemAsNew(item);
             APRandomizer.SaveData.itemsAcquired[item] = (uint)itemCountSoFar;
-            LocationTriggers.ApplyItemToPlayer(item, APRandomizer.SaveData.itemsAcquired[item]);
+            LocationTriggers.ApplyItemToPlayer(item, APRandomizer.SaveData.itemsAcquired[item], true);
 
             // SetPersistentCondition() is not safe to call on the main menu because e.g. it can lead to Switch Profile mistakently copying save data onto other profiles,
             if (LoadManager.GetCurrentScene() != OWScene.TitleScreen)
@@ -605,6 +606,7 @@ public class APRandomizer : ModBehaviour
         AutoNomaiText = config.GetSettingsValue<bool>("Auto Expand Nomai Text");
         ColorNomaiText = config.GetSettingsValue<bool>("LocationAppearanceMatchesContents");
         InstantTranslator = config.GetSettingsValue<bool>("Instant Translator");
+        UnlockNotification = config.GetSettingsValue<bool>("Show Unlock Notification");
         NomaiTextQoL.NomaiTextQoL.TranslateTime = InstantTranslator ? 0f : 0.2f;
 
         InGameAPConsole?.ModSettingsChanged(config);

--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -503,6 +503,7 @@ public class APRandomizer : ModBehaviour
             Orbits.OnCompleteSceneLoad(scene, loadScene);
             Spawn.OnCompleteSceneLoad(scene, loadScene);
             Compatibility.NomaiVR.VRToolHolster.OnCompleteSceneLoad(scene, loadScene);
+            Compatibility.NomaiVR.VRShipMonitorText.OnCompleteSceneLoad(scene, loadScene);
             Hints.OnCompleteSceneLoad();
             // Hearth's Neighbor 2: Magistarium custom item impls
             MemoryCubeInterface.OnCompleteSceneLoad();

--- a/mod/APRandomizer.cs
+++ b/mod/APRandomizer.cs
@@ -502,6 +502,7 @@ public class APRandomizer : ModBehaviour
             DarkBrambleLayout.OnCompleteSceneLoad(scene, loadScene);
             Orbits.OnCompleteSceneLoad(scene, loadScene);
             Spawn.OnCompleteSceneLoad(scene, loadScene);
+            Compatibility.NomaiVR.VRToolHolster.OnCompleteSceneLoad(scene, loadScene);
             Hints.OnCompleteSceneLoad();
             // Hearth's Neighbor 2: Magistarium custom item impls
             MemoryCubeInterface.OnCompleteSceneLoad();

--- a/mod/ArchConsoleManager.cs
+++ b/mod/ArchConsoleManager.cs
@@ -70,7 +70,9 @@ public class ArchConsoleManager : MonoBehaviour
 
         APRandomizer.OnSessionOpened += (s) =>
         {
-            s.Locations.CheckedLocationsUpdated += UpdateProgress;
+            // this ends up doing UI work and need to run on the main thread
+            s.Locations.CheckedLocationsUpdated += (checkedLocations) =>
+                MainThreadDispatcher.Enqueue(() => UpdateProgress(checkedLocations));
             session = s;
             APRandomizer.HasSeenSettingsText = false;
         };

--- a/mod/ArchConsoleManager.cs
+++ b/mod/ArchConsoleManager.cs
@@ -39,6 +39,7 @@ public class ArchConsoleManager : MonoBehaviour
     private Material progressMat;
     private Text progressText;
     private ArchipelagoSession session;
+    // only initialized if NomaiVR is loaded
     private VRArchConsole vr;
     // separate from pauseConsoleText.text so we can avoid updating the Text object until the game's paused
     private string pauseConsoleContent = "";
@@ -61,7 +62,8 @@ public class ArchConsoleManager : MonoBehaviour
 
     private void Start()
     {
-        vr = new VRArchConsole();
+        if (VRCompatibility.IsNomaiVRLoaded)
+            vr = new VRArchConsole();
         
         ConsoleMuted = APRandomizer.Instance.ModHelper.Config.GetSettingsValue<bool>("AP Console: Mute");
         FilterPlayer = APRandomizer.Instance.ModHelper.Config.GetSettingsValue<bool>("AP Console: About Me Filter");
@@ -112,7 +114,7 @@ public class ArchConsoleManager : MonoBehaviour
 
     private void Update()
     {
-        if (vr.vrLoaded && console != null)
+        if (vr != null && console != null)
         {
             vr.Update(console);
         }
@@ -176,8 +178,7 @@ public class ArchConsoleManager : MonoBehaviour
         consoleText = console.GetComponentInChildren<InputField>();
         pauseConsoleVisuals.SetActive(false);
 
-        if (vr.vrLoaded)
-            vr.SetUpConsoleForVR(console);
+        vr?.SetUpConsoleForVR(console, consoleText);
 
         // These are messages we really want the player to see, so show in both consoles (sadly we can't make a ding noise this early)
         foreach (string entry in WakeupConsoleMessages)

--- a/mod/ArchConsoleManager.cs
+++ b/mod/ArchConsoleManager.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using ArchipelagoRandomizer.Compatibility.NomaiVR;
 using UnityEngine;
 using UnityEngine.UI;
 using static ArchipelagoRandomizer.DeathLinkManager;
@@ -38,6 +39,7 @@ public class ArchConsoleManager : MonoBehaviour
     private Material progressMat;
     private Text progressText;
     private ArchipelagoSession session;
+    private VRArchConsole vr;
     // separate from pauseConsoleText.text so we can avoid updating the Text object until the game's paused
     private string pauseConsoleContent = "";
     private bool pauseConsoleNeedsUpdate = false;
@@ -59,6 +61,8 @@ public class ArchConsoleManager : MonoBehaviour
 
     private void Start()
     {
+        vr = new VRArchConsole();
+        
         ConsoleMuted = APRandomizer.Instance.ModHelper.Config.GetSettingsValue<bool>("AP Console: Mute");
         FilterPlayer = APRandomizer.Instance.ModHelper.Config.GetSettingsValue<bool>("AP Console: About Me Filter");
         DropAllAPServerMessages = APRandomizer.Instance.ModHelper.Config.GetSettingsValue<bool>("AP Console: Drop All AP Server Messages");
@@ -108,6 +112,11 @@ public class ArchConsoleManager : MonoBehaviour
 
     private void Update()
     {
+        if (vr.vrLoaded && console != null)
+        {
+            vr.Update(console);
+        }
+
         // Clear console entries after enough time has passed
         if (gameplayConsoleTimers != null && gameplayConsoleTimers.Count > 0)
         {
@@ -166,6 +175,9 @@ public class ArchConsoleManager : MonoBehaviour
         filterButton.onClick.AddListener(OnClickFilterButton);
         consoleText = console.GetComponentInChildren<InputField>();
         pauseConsoleVisuals.SetActive(false);
+
+        if (vr.vrLoaded)
+            vr.SetUpConsoleForVR(console);
 
         // These are messages we really want the player to see, so show in both consoles (sadly we can't make a ding noise this early)
         foreach (string entry in WakeupConsoleMessages)

--- a/mod/ArchConsoleManager.cs
+++ b/mod/ArchConsoleManager.cs
@@ -358,7 +358,7 @@ public class ArchConsoleManager : MonoBehaviour
             Item item = ItemNames.itemNamesReversed[tokens[0]];
             uint count = uint.Parse(tokens[1]);
             APRandomizer.OWMLModConsole.WriteLine($"Received debug command '{text}'. Calling ApplyItemToPlayer({item}, {count}).");
-            LocationTriggers.ApplyItemToPlayer(item, count);
+            LocationTriggers.ApplyItemToPlayer(item, count, true);
             consoleText.text = "";
             return;
         }

--- a/mod/ArchipelagoRandomizer.csproj
+++ b/mod/ArchipelagoRandomizer.csproj
@@ -53,7 +53,7 @@
     <Target Name="CopyMCNet" AfterTargets="PostBuildEvent">
 	    <!-- The OS condition is for skipping this in CI -->
 	    <Copy Condition="'$(OS)' == 'Windows_NT'"
-			    SourceFiles="C:\Users\j-pop\.nuget\packages\archipelago.multiclient.net\$(ArchipelagoMultiClientDotNetVersion)\lib\net45\Archipelago.MultiClient.Net.dll"
+			    SourceFiles="C:\Users\$(UserName)\.nuget\packages\archipelago.multiclient.net\$(ArchipelagoMultiClientDotNetVersion)\lib\net45\Archipelago.MultiClient.Net.dll"
 			    DestinationFolder="$(TargetDir)"
 			    SkipUnchangedFiles="true" />
     </Target>

--- a/mod/Compatibility/NomaiVR/VRArchConsole.cs
+++ b/mod/Compatibility/NomaiVR/VRArchConsole.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
+
+/// <summary>
+/// Console compatibility for the NomaiVR mod
+/// </summary>
+// TODO: One known issue that currently remains: it's not possible to enter text into the console in VR.
+public class VRArchConsole
+{
+    public readonly bool vrLoaded = VRCompatibility.IsNomaiVRLoaded;
+
+    // The geometry of the first console we create under VR.
+    // When reloading (for example after resetting the loop) NomaiVR mutates our prefab for the ArchRandoCanvas,
+    // so we need to restore the geometry on every subsequent creation of the console.
+    private CachedGeometry cachedConsoleGeometry;
+
+    private static readonly Type NomaiVrFollowTargetType =
+        Type.GetType("NomaiVR.ReusableBehaviours.FollowTarget, NomaiVR");
+
+    private class CachedGeometry
+    {
+        internal Vector2 pivot;
+        internal Vector2 sizeDelta;
+        internal Vector2 anchorMin;
+        internal Vector2 anchorMax;
+        internal Vector2 anchoredPosition;
+    }
+
+    public void Update(GameObject console)
+    {
+        if (NomaiVrFollowTargetType != null)
+        {
+            // Remove NomaiVR's FollowTarget, so just our own VRConsoleFollow remains. NomaiVR scans on scene load and
+            // adds this component, but we can't reliably time this, so we remove it every frame.
+            // XXX: would of course be better to remove it just when needed.
+            var nomaiFollow = console.GetComponent(NomaiVrFollowTargetType);
+            if (nomaiFollow != null) Object.Destroy(nomaiFollow);
+        }
+
+        // NomaiVR doesn't really expect objects to be used both in gameplay and in menus and moved between them
+        // (this also causes a bunch of other issues, see SetUpConsoleForVR), so we need to make sure we re-activate
+        // the object if NomaiVR has deactivated it due to a pause->gameplay transition.
+        if (!console.activeSelf) console.SetActive(true);
+    }
+
+    // Setup console for the VR world space & tracking
+    // 
+    // NomaiVR makes VR work by scanning for ScreenSpaceOverlay canvases once per scene load and
+    // converting them to world space, but this breaks when pausing or scene reloading, since that logic essentially
+    // only runs once. To avoid these issues, we convert the console to world space ourselves but this also means we
+    // must take care of positioning the canvas, which this component does.
+    //
+    // We also add our own tracking component (VRConsoleFollow). We need to add our own, since when we init the console
+    // the camera doesn't exist yet, but NomaiVR's FollowTarget tries to cache it along other issues, leading to it
+    // not actually showing.
+    // 
+    // It's also probably best not to rely on NomaiVR implementation details when we end up positioning the console
+    // ourselves anyway (especially with the pause menu interactions & the whole re-create on scene load).
+    public void SetUpConsoleForVR(GameObject console)
+    {
+        var rootCanvas = console.GetComponent<Canvas>();
+        if (rootCanvas == null) rootCanvas = console.GetComponentInChildren<Canvas>(true);
+        if (rootCanvas == null)
+        {
+            APRandomizer.OWMLModConsole.WriteLine("Could not find a Canvas on the AP console to set up for VR.",
+                OWML.Common.MessageType.Warning);
+            return;
+        }
+
+        foreach (var c in console.GetComponentsInChildren<Canvas>(true))
+            if (c.renderMode == RenderMode.ScreenSpaceOverlay)
+                c.renderMode = RenderMode.WorldSpace;
+
+        // Mirror NomaiVR's AdjustScaler for in-game canvases (constant pixel size, then shrink the whole canvas).
+        var scaler = rootCanvas.GetComponent<CanvasScaler>();
+        if (scaler != null)
+        {
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ConstantPixelSize;
+            scaler.scaleFactor = 1;
+            scaler.referencePixelsPerUnit = 100;
+        }
+
+        rootCanvas.transform.localScale = Vector3.one * 0.001f; // ~1px → 1mm in world space
+
+        // Restore geometry to the initial prefab values, see comment at cachedConsoleGeometry
+        var rt = rootCanvas.GetComponent<RectTransform>();
+        if (cachedConsoleGeometry == null)
+        {
+            cachedConsoleGeometry = new CachedGeometry
+            {
+                pivot = rt.pivot,
+                sizeDelta = rt.sizeDelta,
+                anchorMin = rt.anchorMin,
+                anchorMax = rt.anchorMax,
+                anchoredPosition = rt.anchoredPosition,
+            };
+        }
+        else
+        {
+            rt.anchorMin = cachedConsoleGeometry.anchorMin;
+            rt.anchorMax = cachedConsoleGeometry.anchorMax;
+            rt.pivot = cachedConsoleGeometry.pivot;
+            rt.sizeDelta = cachedConsoleGeometry.sizeDelta;
+            rt.anchoredPosition = cachedConsoleGeometry.anchoredPosition;
+        }
+
+        if (rootCanvas.GetComponent<VRConsoleFollow>() == null)
+            rootCanvas.gameObject.AddComponent<VRConsoleFollow>();
+    }
+}

--- a/mod/Compatibility/NomaiVR/VRArchConsole.cs
+++ b/mod/Compatibility/NomaiVR/VRArchConsole.cs
@@ -6,17 +6,17 @@ using Object = UnityEngine.Object;
 namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
 
 /// <summary>
-/// Console compatibility for the NomaiVR mod
+/// Console compatibility for the NomaiVR mod.
+/// (Text entry into the console in VR is handled separately by <see cref="VRConsoleKeyboard"/>.)
 /// </summary>
-// TODO: One known issue that currently remains: it's not possible to enter text into the console in VR.
 public class VRArchConsole
 {
-    public readonly bool vrLoaded = VRCompatibility.IsNomaiVRLoaded;
-
     // The geometry of the first console we create under VR.
     // When reloading (for example after resetting the loop) NomaiVR mutates our prefab for the ArchRandoCanvas,
     // so we need to restore the geometry on every subsequent creation of the console.
     private CachedGeometry cachedConsoleGeometry;
+
+    private VRConsoleKeyboard vrConsoleKeyboard = new();
 
     private static readonly Type NomaiVrFollowTargetType =
         Type.GetType("NomaiVR.ReusableBehaviours.FollowTarget, NomaiVR");
@@ -60,7 +60,10 @@ public class VRArchConsole
     // 
     // It's also probably best not to rely on NomaiVR implementation details when we end up positioning the console
     // ourselves anyway (especially with the pause menu interactions & the whole re-create on scene load).
-    public void SetUpConsoleForVR(GameObject console)
+    //
+    // Additionally, this hands the console's InputField to VRConsoleKeyboard (via Configure) so text entry works
+    // in VR.
+    public void SetUpConsoleForVR(GameObject console, InputField consoleText)
     {
         var rootCanvas = console.GetComponent<Canvas>();
         if (rootCanvas == null) rootCanvas = console.GetComponentInChildren<Canvas>(true);
@@ -110,5 +113,7 @@ public class VRArchConsole
 
         if (rootCanvas.GetComponent<VRConsoleFollow>() == null)
             rootCanvas.gameObject.AddComponent<VRConsoleFollow>();
+
+        vrConsoleKeyboard.Configure(consoleText);
     }
 }

--- a/mod/Compatibility/NomaiVR/VRCompatibility.cs
+++ b/mod/Compatibility/NomaiVR/VRCompatibility.cs
@@ -1,0 +1,9 @@
+﻿namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
+
+/// <summary>
+/// Compatibility for the NomaiVR mod
+/// </summary>
+public static class VRCompatibility
+{
+    public static bool IsNomaiVRLoaded => APRandomizer.Instance.ModHelper.Interaction.ModExists("Raicuparta.NomaiVR");
+}

--- a/mod/Compatibility/NomaiVR/VRConsoleFollow.cs
+++ b/mod/Compatibility/NomaiVR/VRConsoleFollow.cs
@@ -5,7 +5,7 @@ namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
 /// <summary>
 /// Keeps the in-game AP console (converted to a world-space canvas) positioned in front of the player in VR.
 ///
-/// This class does not cache the camera unlike NomaiVR's `FollowTarget`. See VRArchConsoleCompatibility on
+/// This class does not cache the camera unlike NomaiVR's `FollowTarget`. See VRArchConsole on
 /// why that's important.
 /// </summary>
 public class VRConsoleFollow : MonoBehaviour

--- a/mod/Compatibility/NomaiVR/VRConsoleFollow.cs
+++ b/mod/Compatibility/NomaiVR/VRConsoleFollow.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
+
+/// <summary>
+/// Keeps the in-game AP console (converted to a world-space canvas) positioned in front of the player in VR.
+///
+/// This class does not cache the camera unlike NomaiVR's `FollowTarget`. See VRArchConsoleCompatibility on
+/// why that's important.
+/// </summary>
+public class VRConsoleFollow : MonoBehaviour
+{
+    // Offset relative to the player transform. Mirrors NomaiVR's Menus.AddFollowTarget in-game placement;
+    // could be adjusted to tweak the positioning
+    public Vector3 localPosition = new Vector3(0f, 0.75f, 1.5f);
+
+    private Transform target;
+
+    private void OnEnable()
+    {
+        Camera.onPreCull += HandlePreCull;
+    }
+
+    private void OnDisable()
+    {
+        Camera.onPreCull -= HandlePreCull;
+    }
+
+    private void HandlePreCull(Camera camera)
+    {
+        if (target == null) target = Locator.GetPlayerTransform();
+        if (target == null) return;
+
+        transform.position = target.TransformPoint(localPosition);
+        transform.rotation = target.rotation;
+    }
+}

--- a/mod/Compatibility/NomaiVR/VRConsoleKeyboard.cs
+++ b/mod/Compatibility/NomaiVR/VRConsoleKeyboard.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using HarmonyLib;
+using UnityEngine.UI;
+
+namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
+
+/// <summary>
+/// Makes the in-game AP console's text input work under NomaiVR.
+///
+/// NomaiVR opens the SteamVR overlay keyboard whenever any UnityEngine.UI.InputField is activated (a global
+/// Harmony patch in NomaiVR's VirtualKeyboard module), but the half that reads the typed text back out of the
+/// keyboard only exists in the title scene (its MonoBehaviour is gated to OWScene.TitleScreen). So in gameplay
+/// the keyboard opens but the text is never written back, and NomaiVR never submits it either (the title
+/// connection menu submits via a separate Connect button).
+///
+/// We add the missing half ourselves, scoped to our console field: listen for SteamVR's VREvent_KeyboardClosed,
+/// read the typed text, write it into our InputField, and submit it through the normal onEndEdit path.
+/// </summary>
+public class VRConsoleKeyboard
+{
+    // The console InputField the keyboard should write back into.
+    private InputField consoleField;
+
+    // The last InputField that was activated (any, even if not ours), to know if we need to process the result
+    private static InputField lastActivatedField;
+
+    private bool subscribed;
+    private bool reflectionFailed;
+
+    // Cached reflection handles (need to cache them for calls in OnKeyboardClosed)
+    private static PropertyInfo steamVrInstanceProp; // static SteamVR SteamVR.instance
+    private static PropertyInfo steamVrOverlayProp; // CVROverlay SteamVR.overlay
+    private static MethodInfo getKeyboardTextMethod; // uint CVROverlay.GetKeyboardText(StringBuilder, uint)
+
+    /// <summary>
+    /// Point the keyboard write-back at the current console InputField and make sure we're subscribed to the
+    /// SteamVR keyboard-closed event. Safe to call every loop; the subscription is only created once.
+    /// </summary>
+    public void Configure(InputField newConsoleField)
+    {
+        consoleField = newConsoleField;
+        // we do this on Configure and not inside the constructor because that may run too early.
+        EnsureSubscribed();
+    }
+
+    private void EnsureSubscribed()
+    {
+        if (subscribed || reflectionFailed) return;
+
+        try
+        {
+            var steamVrType = ResolveSteamVrType("Valve.VR.SteamVR");
+            var steamVrEventsType = ResolveSteamVrType("Valve.VR.SteamVR_Events");
+            var eventTypeEnum = ResolveSteamVrType("Valve.VR.EVREventType");
+            var vrEventStructType = ResolveSteamVrType("Valve.VR.VREvent_t");
+            if (steamVrType == null || steamVrEventsType == null || eventTypeEnum == null || vrEventStructType == null)
+                throw new Exception(
+                    "Could not resolve one or more SteamVR types (SteamVR, SteamVR_Events, EVREventType, VREvent_t).");
+
+            steamVrInstanceProp = steamVrType.GetProperty("instance", BindingFlags.Public | BindingFlags.Static);
+            steamVrOverlayProp = steamVrType.GetProperty("overlay", BindingFlags.Public | BindingFlags.Instance);
+            // CVROverlay.GetKeyboardText(StringBuilder pchText, uint cchText)
+            var overlayType = steamVrOverlayProp?.PropertyType;
+            getKeyboardTextMethod =
+                overlayType?.GetMethod("GetKeyboardText", new[] { typeof(StringBuilder), typeof(uint) });
+            if (steamVrInstanceProp == null || steamVrOverlayProp == null || getKeyboardTextMethod == null)
+                throw new Exception("Could not resolve SteamVR.instance / .overlay / CVROverlay.GetKeyboardText.");
+
+            // SteamVR_Events.System(EVREventType) -> action object whose Listen takes a UnityAction<VREvent_t>.
+            var systemMethod = steamVrEventsType.GetMethod(
+                "System", BindingFlags.Public | BindingFlags.Static, null,
+                new[] { eventTypeEnum }, null
+            );
+            if (systemMethod == null)
+                throw new Exception("Could not resolve SteamVR_Events.System(EVREventType).");
+
+            var keyboardClosed = Enum.Parse(eventTypeEnum, "VREvent_KeyboardClosed");
+            var action = systemMethod.Invoke(null, new[] { keyboardClosed });
+            if (action == null)
+                throw new Exception("SteamVR_Events.System(VREvent_KeyboardClosed) returned null.");
+
+            var listenMethod = action.GetType().GetMethod("Listen");
+            if (listenMethod == null)
+                throw new Exception("Could not resolve Listen(...) on the SteamVR event action.");
+
+            // Build a UnityAction<VREvent_t> that ignores its arg and calls our parameterless handler. We can't
+            // name VREvent_t at compile time, so construct the closed delegate type and lambda via reflection.
+            var unityActionClosed = listenMethod.GetParameters()[0].ParameterType;
+            var evtParam = Expression.Parameter(vrEventStructType, "evt");
+            // Must be public: a compiled LambdaExpression runs from an anonymously-hosted dynamic method that
+            // enforces member visibility, so calling a private method here throws MethodAccessException.
+            var handler = typeof(VRConsoleKeyboard).GetMethod(nameof(OnKeyboardClosed),
+                BindingFlags.Public | BindingFlags.Instance);
+            var lambda = Expression.Lambda(
+                unityActionClosed, Expression.Call(Expression.Constant(this), handler), evtParam);
+            var del = lambda.Compile();
+
+            listenMethod.Invoke(action, new object[] { del });
+            subscribed = true;
+            APRandomizer.OWMLModConsole.WriteLine(
+                "VRConsoleKeyboard: subscribed to SteamVR VREvent_KeyboardClosed for console text entry.");
+        }
+        catch (Exception e)
+        {
+            reflectionFailed = true; // don't spam retries every loop
+            APRandomizer.OWMLModConsole.WriteLine(
+                $"VRConsoleKeyboard: failed to set up SteamVR keyboard write-back; console text entry will not work in VR.\n{e}",
+                OWML.Common.MessageType.Warning);
+        }
+    }
+
+    private static Type ResolveSteamVrType(string fullName)
+    {
+        // SteamVR.dll is deployed/loaded by NomaiVR, so it should already be in the AppDomain.
+        var type = Type.GetType($"{fullName}, SteamVR");
+        if (type != null) return type;
+
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Select(a => a.GetType(fullName))
+            .FirstOrDefault(t => t != null);
+    }
+
+    /// <summary>
+    /// Fires (on the Unity main thread) when the SteamVR overlay keyboard is closed. If it was opened for our
+    /// console field, read the typed text and submit it through the normal console path.
+    /// </summary>
+    public void OnKeyboardClosed()
+    {
+        try
+        {
+            // Guard: only act on our own console field.
+            if (consoleField == null || lastActivatedField == null || lastActivatedField != consoleField)
+                return;
+
+            var instance = steamVrInstanceProp.GetValue(null);
+            if (instance == null) return;
+            var overlay = steamVrOverlayProp.GetValue(instance);
+            if (overlay == null) return;
+
+            var sb = new StringBuilder(256);
+            getKeyboardTextMethod.Invoke(overlay, new object[] { sb, (uint)256 });
+
+            // Submit through the existing onEndEdit listener (ArchConsoleManager.OnConsoleEntry), which handles
+            // text submit.
+            var entered = sb.ToString();
+            consoleField.text = entered;
+            consoleField.onEndEdit.Invoke(entered);
+            // Clear before deactivating to prevent possible double submits if text submit doesn't clear
+            consoleField.text = string.Empty;
+            consoleField.DeactivateInputField();
+        }
+        catch (Exception e)
+        {
+            APRandomizer.OWMLModConsole.WriteLine($"VRConsoleKeyboard.OnKeyboardClosed failed:\n{e}",
+                OWML.Common.MessageType.Error);
+        }
+    }
+
+    /// <summary>
+    /// Records which InputField the SteamVR keyboard was most recently opened for, mirroring NomaiVR's own
+    /// ActivateInputField patch. Only active when NomaiVR is loaded.
+    /// </summary>
+    [HarmonyPatch(typeof(InputField), nameof(InputField.ActivateInputField))]
+    private static class TrackActivatedFieldPatch
+    {
+        [HarmonyPostfix]
+        private static void Postfix(InputField __instance)
+        {
+            if (!VRCompatibility.IsNomaiVRLoaded) return;
+            lastActivatedField = __instance;
+        }
+    }
+}

--- a/mod/Compatibility/NomaiVR/VRLandingCamera.cs
+++ b/mod/Compatibility/NomaiVR/VRLandingCamera.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+
+namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
+
+/// <summary>
+/// Patches EnterLandingView to re-disable the landing cam. NomaiVR enables it, along with light and audio,
+/// even if our Prefix in LandingCamera "disables" it.
+/// </summary>
+[HarmonyPatch]
+public class VRLandingCamera
+{
+    [HarmonyPostfix, HarmonyPatch(typeof(ShipCockpitController), nameof(ShipCockpitController.EnterLandingView))]
+    public static void ShipCockpitController_EnterLandingView_Postfix(ShipCockpitController __instance)
+    {
+        if (VRCompatibility.IsNomaiVRLoaded && !LandingCamera.hasLandingCamera && __instance._landingCam.enabled)
+        {
+            __instance._landingCam.enabled = false;
+            __instance._landingLight.SetOn(false);
+            __instance._shipAudioController.PlayLandingCamOff();
+        }
+    }
+}

--- a/mod/Compatibility/NomaiVR/VRShipMonitorText.cs
+++ b/mod/Compatibility/NomaiVR/VRShipMonitorText.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
+
+/// <summary>
+/// NomaiVR ship-cockpit monitor text.
+/// 
+/// Replaces "interact with screen to activate" with "not available" if the relevant items are not unlocked.
+/// </summary>
+internal static class VRShipMonitorText
+{
+
+    // The GameObject names NomaiVR gives the three monitor texts (Ship{Signalscope,Probe,LandingCam}Interact.Awake).
+    private static readonly Dictionary<string, Item> textObjectNames = new()
+    {
+        ["VrShipSignalscopeText"] = Item.Signalscope,
+        ["VrShipProbeMonitorText"] = Item.Scout,
+        ["VrLandingCamText"] = Item.LandingCamera,
+    };
+
+    private class ManagedText
+    {
+        public Text text;
+        public string originalText;
+        public Color originalColor;
+    }
+
+    private static readonly Dictionary<Item, ManagedText> managedTexts = new();
+
+    private static readonly Color UnavailableColor = new(1f, 0.4f, 0.3f, 0.1f);
+
+    // How many frames to keep retrying the scene-load sweep while waiting for NomaiVR to create the texts.
+    private const int MaxSweepAttempts = 10;
+
+    private static bool IsToolOwned(Item tool) => tool switch
+    {
+        Item.Signalscope => SignalscopeManager.hasSignalscope,
+        Item.Scout => Scout.hasScout,
+        Item.LandingCamera => LandingCamera.hasLandingCamera,
+        _ => true, // not relevant
+    };
+
+    /// <summary>
+    /// Called from APRandomizer's OnCompleteSceneLoad dispatcher. NomaiVR (re)creates the ship monitor texts on every
+    /// SolarSystem load, so we re-find them and apply their text/color here.
+    /// </summary>
+    public static void OnCompleteSceneLoad(OWScene scene, OWScene loadScene)
+    {
+        if (!VRCompatibility.IsNomaiVRLoaded) return;
+        if (loadScene != OWScene.SolarSystem) return;
+
+        // The texts are recreated with the ship, so drop the stale refs before re-registering.
+        managedTexts.Clear();
+
+        // NomaiVR creates the texts in its module Start(), which runs after OnCompleteSceneLoad, so we continuously
+        // retry until they exist.
+        MainThreadDispatcher.Enqueue(() => TryRegisterAndApply(0));
+    }
+
+    private static void TryRegisterAndApply(int attempt)
+    {
+        if (!VRCompatibility.IsNomaiVRLoaded) return;
+
+        // Register and apply each text as we find it. The three interact receivers are created together in
+        // ShipBody.Start's postfix.
+        foreach (var text in Object.FindObjectsOfType<Text>())
+        {
+            if (!textObjectNames.TryGetValue(text.gameObject.name, out var tool)) continue;
+            if (managedTexts.ContainsKey(tool)) continue; // keep the pristine first capture
+
+            managedTexts[tool] = new ManagedText { text = text, originalText = text.text, originalColor = text.color };
+            ApplyText(tool);
+        }
+
+        if (managedTexts.Count >= textObjectNames.Count) return;
+
+        if (attempt < MaxSweepAttempts)
+            MainThreadDispatcher.Enqueue(() => TryRegisterAndApply(attempt + 1));
+        else
+            APRandomizer.OWMLModConsole.WriteLine(
+                $"Could not find all NomaiVR ship monitor texts (found {managedTexts.Count}/{textObjectNames.Count}); " +
+                "the VR \"not available\" tool prompts may be incomplete.",
+                OWML.Common.MessageType.Warning);
+    }
+
+    /// <summary>Updates the monitor text for the given item.</summary>
+    public static void ApplyManagedTextForItem(Item item)
+    {
+        if (item is Item.Signalscope or Item.Scout or Item.LandingCamera)
+        {
+            ApplyText(item);
+        }
+    }
+
+    private static void ApplyText(Item tool)
+    {
+        if (!managedTexts.TryGetValue(tool, out var managed) || managed.text == null) return;
+
+        if (IsToolOwned(tool))
+        {
+            managed.text.text = managed.originalText;
+            managed.text.color = managed.originalColor;
+        }
+        else
+        {
+            // Keep NomaiVR's "<color=grey>TOOL NAME</color>" header (first line), swap the action line for
+            // "not available". The inline grey overrides Text.color, so only "not available" takes the red tint.
+            var header = managed.originalText.Split('\n')[0];
+            managed.text.text = $"{header}\n\nnot available";
+            managed.text.color = UnavailableColor;
+        }
+    }
+}

--- a/mod/Compatibility/NomaiVR/VRSpawnFacing.cs
+++ b/mod/Compatibility/NomaiVR/VRSpawnFacing.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+
+namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
+
+/// <summary>
+/// NomaiVR has a feature where both the player and Timber Hearth itself are rotated to make sure the player
+/// wakes up (standing in VR), facing Giant's Deep and witnessing the probe launch.
+///
+/// This set of patches disables this when either the orbits are randomized or the player doesn't spawn on TH,
+/// since in both cases the player won't be facing Giant's Deep anyway and the patches NomaiVR apply cause
+/// more problems than they solve.
+/// </summary>
+internal static class VRSpawnFacing
+{
+    private static readonly Harmony harmony = new("Ixrec.ArchipelagoRandomizer.NomaiVRSpawnFacing");
+
+    private static bool installed;
+    private static bool installFailed;
+
+    /// <summary>
+    /// Installs the NomaiVR spawn-facing suppression patches once NomaiVR is loaded.
+    /// </summary>
+    public static void EnsurePatches()
+    {
+        if (installed || installFailed) return;
+        if (!VRCompatibility.IsNomaiVRLoaded) return; // NomaiVR not up yet; try again on a later scene load.
+
+        var patchType = Type.GetType("NomaiVR.EffectFixes.FixProbeCannonVisibility+Behaviour+Patch, NomaiVR");
+        var rotatePlayer = patchType?.GetMethod("RotatePlayer", BindingFlags.NonPublic | BindingFlags.Static);
+        var rotateTimberHearth = patchType?.GetMethod("RotateTimberHearth", BindingFlags.NonPublic | BindingFlags.Static);
+
+        if (patchType == null || rotatePlayer == null || rotateTimberHearth == null)
+        {
+            installFailed = true;
+            APRandomizer.OWMLModConsole.WriteLine(
+                "Could not resolve NomaiVR's FixProbeCannonVisibility methods for the spawn-facing fix; " +
+                "NomaiVR's 'face Giant's Deep' logic will not be suppressed on non-vanilla spawns or randomized orbits.",
+                OWML.Common.MessageType.Warning);
+            return;
+        }
+
+        var skipPrefix = new HarmonyMethod(typeof(VRSpawnFacing), nameof(SuppressGiantsDeepFacing_Prefix));
+        harmony.Patch(rotatePlayer, prefix: skipPrefix);
+        harmony.Patch(rotateTimberHearth, prefix: skipPrefix);
+        installed = true;
+    }
+
+    /// <summary>
+    /// Harmony prefix shared by both NomaiVR methods. Returning false skips the original to suppress rotation patches.
+    /// </summary>
+    private static bool SuppressGiantsDeepFacing_Prefix() => !ShouldSuppressGiantsDeepFacing();
+
+    private static bool ShouldSuppressGiantsDeepFacing() =>
+        Spawn.spawnChoice is not (Spawn.SpawnChoice.Vanilla or Spawn.SpawnChoice.TimberHearth)
+        || Orbits.AreOrbitsRandomized;
+}

--- a/mod/Compatibility/NomaiVR/VRToolHolster.cs
+++ b/mod/Compatibility/NomaiVR/VRToolHolster.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using Object = UnityEngine.Object;
+
+namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
+
+/// <summary>
+/// Fixes pre-suit tool-grab softlock under NomaiVR.
+///
+/// NomaiVR does not handle tools not entering tool mode (tools get "stuck in hand"), this breaks tool-equips until
+/// restart when suitless.
+/// </summary>
+[HarmonyPatch]
+internal static class VRToolHolster
+{
+    private static bool reflectionResolved;
+    private static bool reflectionFailed;
+    private static Type holsterToolType;
+    private static FieldInfo modeField;
+    private static FieldInfo handField;
+    private static MethodInfo unequipMethod;
+
+    [HarmonyPostfix, HarmonyPatch(typeof(ToolModeSwapper), nameof(ToolModeSwapper.EquipToolMode))]
+    public static void ToolModeSwapper_EquipToolMode_Postfix(ToolMode mode)
+    {
+        if (!VRCompatibility.IsNomaiVRLoaded) return;
+
+        if (mode != ToolMode.SignalScope && mode != ToolMode.Translator && mode != ToolMode.Probe) return;
+
+        // If the equip succeeded the tool is actually in that mode now -> nothing latched, nothing to do.
+        if (Locator.GetToolModeSwapper()?.IsInToolMode(mode, ToolGroup.Suit) == true) return;
+
+        // The equip failed (vetoed by AP, a suit requirement, or anything else). Reset the holster later
+        // when all this has been processed.
+        MainThreadDispatcher.Enqueue(() => ResetStuckHolster(mode));
+    }
+
+    private static void ResetStuckHolster(ToolMode mode)
+    {
+        if (!VRCompatibility.IsNomaiVRLoaded) return;
+        if (!EnsureReflection()) return;
+
+        // If the tool (somehow) ended up equipped after all, nothing is stuck.
+        if (Locator.GetToolModeSwapper()?.IsInToolMode(mode, ToolGroup.Suit) == true) return;
+
+        foreach (var obj in Object.FindObjectsOfType(holsterToolType))
+        {
+            // Match the holster for this tool mode.
+            if (!(modeField.GetValue(obj) is ToolMode holsterMode) || holsterMode != mode) continue;
+
+            // A non-null `hand` means the holster still thinks it's holding the tool — the latched/stuck state.
+            if (!(handField.GetValue(obj) is Object hand) || hand == null) continue;
+
+            // Call NomaiVR's own Unequip()
+            unequipMethod.Invoke(obj, null);
+            APRandomizer.OWMLModConsole.WriteLine($"reset stuck {mode} holster (NomaiVR softlock prevention)");
+        }
+    }
+
+    /// <summary>Resolves (once) the NomaiVR HolsterTool members we reflect against. Returns false if unavailable.</summary>
+    private static bool EnsureReflection()
+    {
+        if (reflectionResolved) return !reflectionFailed;
+        reflectionResolved = true;
+
+        holsterToolType = Type.GetType("NomaiVR.Tools.HolsterTool, NomaiVR");
+        modeField = holsterToolType?.GetField("mode", BindingFlags.Public | BindingFlags.Instance);
+        handField = holsterToolType?.GetField("hand", BindingFlags.NonPublic | BindingFlags.Instance);
+        unequipMethod = holsterToolType?.GetMethod("Unequip", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        if (holsterToolType == null || modeField == null || handField == null || unequipMethod == null)
+        {
+            reflectionFailed = true;
+            APRandomizer.OWMLModConsole.WriteLine(
+                "Could not resolve NomaiVR HolsterTool members for the tool-holster softlock fix; " +
+                "the pre-suit holster softlock will not be auto-corrected.",
+                OWML.Common.MessageType.Warning);
+        }
+
+        return !reflectionFailed;
+    }
+}

--- a/mod/Compatibility/NomaiVR/VRToolHolster.cs
+++ b/mod/Compatibility/NomaiVR/VRToolHolster.cs
@@ -1,15 +1,22 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
+using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace ArchipelagoRandomizer.Compatibility.NomaiVR;
 
 /// <summary>
-/// Fixes pre-suit tool-grab softlock under NomaiVR.
+/// NomaiVR tool-holster fixes.
 ///
-/// NomaiVR does not handle tools not entering tool mode (tools get "stuck in hand"), this breaks tool-equips until
-/// restart when suitless.
+/// This first generally prevents soft-locks when trying to equip tools suitless: NomaiVR does not handle a tool
+/// failing to enter tool mode (the tool gets "stuck in hand"), which breaks all tool-equips until restart.
+/// We detect the failed equip and reset the stuck holster.
+///
+/// Secondly this hides un-usable holsters in the first place: if the randomizer hasn't granted the Signalscope or
+/// any Translator, they just aren't shown. If any translator is unlocked, it's shown everywhere, but this class
+/// also provides a mechanism to inform the player of unusable translators when in different sectors.
 /// </summary>
 [HarmonyPatch]
 internal static class VRToolHolster
@@ -20,6 +27,12 @@ internal static class VRToolHolster
     private static FieldInfo modeField;
     private static FieldInfo handField;
     private static MethodInfo unequipMethod;
+
+    // the holsters we hide/show by AP ownership, keyed by tool mode.
+    private static readonly Dictionary<ToolMode, GameObject> managedHolsters = new();
+
+    // How many frames to keep retrying the scene-load sweep while waiting for NomaiVR to create the holsters.
+    private const int MaxSweepAttempts = 10;
 
     [HarmonyPostfix, HarmonyPatch(typeof(ToolModeSwapper), nameof(ToolModeSwapper.EquipToolMode))]
     public static void ToolModeSwapper_EquipToolMode_Postfix(ToolMode mode)
@@ -58,6 +71,59 @@ internal static class VRToolHolster
         }
     }
 
+    private static bool IsHidableToolMode(ToolMode mode) =>
+        mode is ToolMode.SignalScope or ToolMode.Translator;
+
+    private static bool IsToolOwned(ToolMode mode) => mode switch
+    {
+        ToolMode.SignalScope => SignalscopeManager.hasSignalscope,
+        ToolMode.Translator => Translator.hasAnyTranslator,
+        _ => true, // we never try to hide anything else
+    };
+
+    /// <summary>
+    /// Called from APRandomizer's OnCompleteSceneLoad dispatcher. NomaiVR (re)creates the holsters on every playable
+    /// scene load, so we re-find them and apply their visibility here.
+    /// </summary>
+    public static void OnCompleteSceneLoad(OWScene scene, OWScene loadScene)
+    {
+        if (!VRCompatibility.IsNomaiVRLoaded) return;
+        // NomaiVR only creates the holsters in its PlayableScenes (SolarSystem + EyeOfTheUniverse).
+        if (loadScene != OWScene.SolarSystem && loadScene != OWScene.EyeOfTheUniverse) return;
+
+        // NomaiVR creates the holsters in its module Start(), which runs after OnCompleteSceneLoad, so we continously
+        // retry until they exist.
+        MainThreadDispatcher.Enqueue(() => TrySetHolsterVisibilityAndRegister(0));
+    }
+
+    private static void TrySetHolsterVisibilityAndRegister(int attempt)
+    {
+        if (!VRCompatibility.IsNomaiVRLoaded || !EnsureReflection()) return;
+
+        // Register and apply each holster as we find it. Signalscope and Translator are separate NomaiVR modules
+        // whose holsters may be created on different frames.
+        foreach (var obj in Object.FindObjectsOfType(holsterToolType))
+        {
+            if (!(modeField.GetValue(obj) is ToolMode mode) || !IsHidableToolMode(mode)) continue;
+            managedHolsters[mode] = ((Component)obj).gameObject;
+            ApplyHolsterAvailability(mode);
+        }
+
+        // Keep retrying until BOTH managed holsters are registered.
+        var haveBoth =
+            managedHolsters.TryGetValue(ToolMode.SignalScope, out var sig) && sig != null &&
+            managedHolsters.TryGetValue(ToolMode.Translator, out var trn) && trn != null;
+        if (!haveBoth && attempt < MaxSweepAttempts)
+            MainThreadDispatcher.Enqueue(() => TrySetHolsterVisibilityAndRegister(attempt + 1));
+    }
+
+    public static void ApplyHolsterAvailability(ToolMode mode)
+    {
+        if (!managedHolsters.TryGetValue(mode, out var go) || go == null) return;
+        var owned = IsToolOwned(mode);
+        if (go.activeSelf != owned) go.SetActive(owned);
+    }
+
     /// <summary>Resolves (once) the NomaiVR HolsterTool members we reflect against. Returns false if unavailable.</summary>
     private static bool EnsureReflection()
     {
@@ -79,5 +145,18 @@ internal static class VRToolHolster
         }
 
         return !reflectionFailed;
+    }
+
+    /// <summary>
+    /// Show a notification telling the player they can't equip the translator.
+    /// 
+    /// In VR the only way to equip the translator is a deliberate holster grab and there's no built-in feedback for
+    /// a rejected grab, so show a HUD notification. This will only show if the suit is equipped, so suitless
+    /// there's still no notification, but that's fine.
+    /// </summary>
+    public static void ShowTranslatorNotAvailableNotification(string cannotTranslatePromptText)
+    {
+        var nd = new NotificationData(NotificationTarget.Player, cannotTranslatePromptText.ToUpper(), 3f, false);
+        NotificationManager.SharedInstance.PostNotification(nd, false);
     }
 }

--- a/mod/InGameTracker/TrackerManager.cs
+++ b/mod/InGameTracker/TrackerManager.cs
@@ -54,10 +54,14 @@ public class TrackerManager : MonoBehaviour
             session = s;
             logic.previouslyObtainedItems = s.Items.AllItemsReceived;
             logic.InitializeAccessibility();
-            s.Items.ItemReceived += logic.RecheckAccessibility;
-            s.Locations.CheckedLocationsUpdated += logic.CheckLocations;
+            // these end up doing UI work and need to run on the main thread
+            s.Items.ItemReceived += (helper) =>
+                MainThreadDispatcher.Enqueue(() => logic.RecheckAccessibility(helper));
+            s.Locations.CheckedLocationsUpdated += (checkedLocations) =>
+                MainThreadDispatcher.Enqueue(() => logic.CheckLocations(checkedLocations));
             logic.CheckLocations(s.Locations.AllLocationsChecked);
-            s.DataStorage.TrackHints(ReadHints);
+            s.DataStorage.TrackHints((hints) =>
+                MainThreadDispatcher.Enqueue(() => ReadHints(hints)));
         };
         APRandomizer.OnSessionClosed += (s, m) =>
         {

--- a/mod/Item.cs
+++ b/mod/Item.cs
@@ -140,6 +140,18 @@ public enum Item
 
 public static class ItemNames
 {
+    private static readonly Item[] Translators = {
+        Item.Translator,
+        Item.TranslatorHGT,
+        Item.TranslatorTH,
+        Item.TranslatorBH,
+        Item.TranslatorGD,
+        Item.TranslatorDB,
+        Item.TranslatorOther,
+        Item.TranslatorDeepB,
+    };
+    public static bool IsTranslator(Item item) => Translators.Contains(item);
+    
     // Used to help the Inventory Tracker show a single "Story Mod Frequencies" entry for all of these similar items
     private static Item[] StoryModFrequencies = {
         Item.FrequencyNeighborDistress,

--- a/mod/ItemImpls/PlayerEquipment/SignalscopeManager.cs
+++ b/mod/ItemImpls/PlayerEquipment/SignalscopeManager.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using System.Threading.Tasks;
+using ArchipelagoRandomizer.Compatibility.NomaiVR;
 
 namespace ArchipelagoRandomizer;
 
@@ -16,6 +17,8 @@ internal class SignalscopeManager
             if (_hasSignalscope != value)
             {
                 _hasSignalscope = value;
+                if (VRCompatibility.IsNomaiVRLoaded)
+                    VRToolHolster.ApplyHolsterAvailability(ToolMode.SignalScope);
             }
         }
     }

--- a/mod/ItemImpls/PlayerEquipment/SignalscopeManager.cs
+++ b/mod/ItemImpls/PlayerEquipment/SignalscopeManager.cs
@@ -32,6 +32,7 @@ internal class SignalscopeManager
         Locator.GetPromptManager().AddScreenPrompt(signalscopeNotAvailablePrompt, PromptPosition.Center, false);
     }
 
+    [HarmonyBefore("Raicuparta.NomaiVR")]
     [HarmonyPrefix, HarmonyPatch(typeof(ToolModeSwapper), nameof(ToolModeSwapper.EquipToolMode))]
     public static bool ToolModeSwapper_EquipToolMode_Prefix(ToolMode mode)
     {

--- a/mod/ItemImpls/PlayerEquipment/Translator.cs
+++ b/mod/ItemImpls/PlayerEquipment/Translator.cs
@@ -133,6 +133,7 @@ internal class Translator
         }
     }
 
+    [HarmonyBefore("Raicuparta.NomaiVR")]
     [HarmonyPrefix, HarmonyPatch(typeof(ToolModeSwapper), nameof(ToolModeSwapper.EquipToolMode))]
     public static bool ToolModeSwapper_EquipToolMode_Prefix(ToolMode mode)
     {

--- a/mod/ItemImpls/PlayerEquipment/Translator.cs
+++ b/mod/ItemImpls/PlayerEquipment/Translator.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using ArchipelagoRandomizer.Compatibility.NomaiVR;
+using HarmonyLib;
 using System.Collections.Generic;
 
 namespace ArchipelagoRandomizer;
@@ -39,6 +40,10 @@ internal class Translator
     public static bool hasDBTranslator = false;
     public static bool hasOtherTranslator = false;
     public static bool hasDeepBTranslator = false;
+
+    public static bool hasAnyTranslator =>
+        hasRegularTranslator || hasHGTTranslator || hasTHTranslator || hasBHTranslator ||
+        hasGDTranslator || hasDBTranslator || hasOtherTranslator || hasDeepBTranslator;
 
     private static TranslatorSector currentTranslatorSector = TranslatorSector.Other;
 
@@ -138,7 +143,11 @@ internal class Translator
     public static bool ToolModeSwapper_EquipToolMode_Prefix(ToolMode mode)
     {
         if (mode == ToolMode.Translator && !hasTranslatorForCurrentSector())
+        {
+            if (VRCompatibility.IsNomaiVRLoaded)
+                VRToolHolster.ShowTranslatorNotAvailableNotification(cannotTranslatePromptText);
             return false;
+        }
         return true;
     }
 

--- a/mod/ItemImpls/Useful/LandingCamera.cs
+++ b/mod/ItemImpls/Useful/LandingCamera.cs
@@ -70,6 +70,7 @@ internal class LandingCamera
         noLandingCameraLiftoffPrompt.SetVisibility(false);
     }
 
+    [HarmonyBefore("Raicuparta.NomaiVR")] // NOTE: There is an additional Postfix for VR compatibility in VRLandingCamera.
     [HarmonyPrefix, HarmonyPatch(typeof(ShipCockpitController), nameof(ShipCockpitController.EnterLandingView))]
     public static bool ShipCockpitController_EnterLandingView_Prefix()
     {

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -455,9 +455,15 @@ internal class LocationTriggers
                 APRandomizer.OWMLModConsole.WriteLine($"unknown item: {item}", OWML.Common.MessageType.Error);
                 break;
         }
-        
-        if (ItemNames.IsTranslator(item) && VRCompatibility.IsNomaiVRLoaded)
-            VRToolHolster.ApplyHolsterAvailability(ToolMode.Translator);
+
+        if (VRCompatibility.IsNomaiVRLoaded)
+        {
+            if (ItemNames.IsTranslator(item))
+            {
+                VRToolHolster.ApplyHolsterAvailability(ToolMode.Translator);
+            }
+            VRShipMonitorText.ApplyManagedTextForItem(item);
+        }
     }
 
 

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -455,6 +455,9 @@ internal class LocationTriggers
                 APRandomizer.OWMLModConsole.WriteLine($"unknown item: {item}", OWML.Common.MessageType.Error);
                 break;
         }
+        
+        if (ItemNames.IsTranslator(item) && VRCompatibility.IsNomaiVRLoaded)
+            VRToolHolster.ApplyHolsterAvailability(ToolMode.Translator);
     }
 
 

--- a/mod/LocationTriggers.cs
+++ b/mod/LocationTriggers.cs
@@ -2,7 +2,9 @@
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using ArchipelagoRandomizer.Compatibility.NomaiVR;
 
 namespace ArchipelagoRandomizer;
 
@@ -281,6 +283,9 @@ internal class LocationTriggers
             { "TT_Tower_BH_1", Location.AT_BH_TOWER }
         };
 
+    private static ScreenPrompt itemUnlockedPrompt;
+    private static CancellationTokenSource itemUnlockedPromptCancelToken;
+
     // no longer in use, keeping as notes for when we edit flavor text to justify some items' existence
     /*static Dictionary<Location, Item> locationToVanillaItem = new Dictionary<Location, Item> {
         { Location.ET_FOSSIL, Item.SilentRunning },
@@ -361,8 +366,11 @@ internal class LocationTriggers
         }
     }
 
-    public static void ApplyItemToPlayer(Item item, uint count)
+    public static void ApplyItemToPlayer(Item item, uint count, bool showNotification = false)
     {
+        if (APRandomizer.UnlockNotification && count > 0 && showNotification)
+            ShowUnlockNotification(item);
+        
         if (ItemNames.itemToFrequency.ContainsKey(item))
         {
             SignalsAndFrequencies.SetFrequencyUsable(ItemNames.itemToFrequency[item], count > 0);
@@ -602,5 +610,30 @@ internal class LocationTriggers
         {
             case "IP_DREAM_LAKE_R2": CheckLocation(Location.VAULT_VISION); break;
         }
+    }
+
+    private static void ShowUnlockNotification(Item item)
+    {
+        var itemName = ItemNames.ItemToName(item);
+        
+        // despite the setting being called "notification", we use a prompt and not a notification, mainly because
+        // some items already show their own notification, and notifications are more "in-universe".
+        if (itemUnlockedPrompt == null)
+        {
+            itemUnlockedPrompt = new ScreenPrompt("");
+            itemUnlockedPrompt.SetDisplayState(ScreenPrompt.DisplayState.Attention);
+            Locator.GetPromptManager().AddScreenPrompt(itemUnlockedPrompt, PromptPosition.Center);
+        }
+            
+        itemUnlockedPrompt.SetText($"Unlocked {itemName}!");
+        itemUnlockedPrompt.SetVisibility(true);
+        
+        itemUnlockedPromptCancelToken?.Cancel();
+        itemUnlockedPromptCancelToken = new CancellationTokenSource();
+        Task.Run(async () => {
+            // when in VR, the prompt is shown attached to the right hand, give the player a bit more time to look at it.
+            await Task.Delay(VRCompatibility.IsNomaiVRLoaded ? 6000 : 3000);
+            itemUnlockedPrompt.SetVisibility(false);
+        }, itemUnlockedPromptCancelToken.Token);
     }
 }

--- a/mod/MainMenu.cs
+++ b/mod/MainMenu.cs
@@ -154,8 +154,11 @@ internal class MainMenu
                 {
                     // we don't overwrite the mod save file and the player's inventory until we're sure we can really start playing this new game
                     APRandomizer.Instance.ModHelper.Storage.Save<APRandomizerSaveData>(saveData, APRandomizer.SaveFileName);
-                    foreach (var kv in APRandomizer.SaveData.itemsAcquired)
-                        LocationTriggers.ApplyItemToPlayer(kv.Key, kv.Value);
+                    if (!APRandomizer.UnlockItemsViaDebugOnly)
+                    {
+                        foreach (var kv in APRandomizer.SaveData.itemsAcquired)
+                            LocationTriggers.ApplyItemToPlayer(kv.Key, kv.Value);
+                    }
 
                     // also wipe the vanilla save file, since we've bypassed the base game code that would normally do this
                     PlayerData.ResetGame();
@@ -178,11 +181,14 @@ internal class MainMenu
         lpu.titleMenuManager = titleManager;
         lpu.mainMenuButton = mainMenuButton;
 
-        // SetPersistentCondition() is not safe to call on the main menu because e.g. it can lead to Switch Profile mistakently copying save data onto other profiles,
-        // so we wait to initialize the autosplitter conditions until we know we're about to leave the main menu and won't be switching profiles any more.
-        foreach (var kv in APRandomizer.SaveData.itemsAcquired)
-            if (ItemNames.itemToPersistentCondition.TryGetValue(kv.Key, out var condition))
-                PlayerData.SetPersistentCondition(condition, kv.Value > 0); // for now, only unique items have conditions
+        if (!APRandomizer.UnlockItemsViaDebugOnly)
+        {
+            // SetPersistentCondition() is not safe to call on the main menu because e.g. it can lead to Switch Profile mistakently copying save data onto other profiles,
+            // so we wait to initialize the autosplitter conditions until we know we're about to leave the main menu and won't be switching profiles any more.
+            foreach (var kv in APRandomizer.SaveData.itemsAcquired)
+                if (ItemNames.itemToPersistentCondition.TryGetValue(kv.Key, out var condition))
+                    PlayerData.SetPersistentCondition(condition, kv.Value > 0); // for now, only unique items have conditions
+        }
     }
 
     class LoadProgressUpdater : MonoBehaviour

--- a/mod/MainThreadDispatcher.cs
+++ b/mod/MainThreadDispatcher.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Concurrent;
+using OWML.Common;
+
+namespace ArchipelagoRandomizer;
+
+/// <summary>
+/// Delegate work from threads to the Unity main thread. Work is executed during APRandomizer.Update().
+/// To be used when tasks need to happen on the main thread (e.g. UI updates).
+/// </summary>
+public static class MainThreadDispatcher
+{
+    private static readonly ConcurrentQueue<Action> queue = new();
+
+    /// <summary>
+    /// Queues an action to run on the Unity main thread during the next APRandomizer.Update().
+    /// Safe to call from any thread.
+    /// </summary>
+    public static void Enqueue(Action action)
+    {
+        if (action != null)
+            queue.Enqueue(action);
+    }
+
+    /// <summary>
+    /// Runs the queued actions.
+    /// Must be called from main thread.
+    /// </summary>
+    public static void DrainOnMainThread()
+    {
+        // We only run as many tasks as there were when we entered this method to prevent starvation in case
+        // we are spammed with actions.
+        int budget = queue.Count;
+        while (budget-- > 0 && queue.TryDequeue(out var action))
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                APRandomizer.OWMLModConsole.WriteLine(
+                    $"MainThreadDispatcher action threw an exception: {ex.Message}\n{ex.StackTrace}",
+                    MessageType.Error);
+            }
+        }
+    }
+}

--- a/mod/Orbits.cs
+++ b/mod/Orbits.cs
@@ -24,6 +24,8 @@ internal class Orbits
     private static Dictionary<string, long> OrbitAngles = null;
     private static Dictionary<string, Vector3> RotationAxes = null;
 
+    internal static bool AreOrbitsRandomized => PlanetOrder != null || OrbitAngles != null || RotationAxes != null;
+
     public static void ApplySlotData(object planetOrderSlotData, object orbitAnglesSlotData, object rotationAxesSlotData)
     {
         PlanetOrder = null;

--- a/mod/default-config.json
+++ b/mod/default-config.json
@@ -62,6 +62,12 @@
       "tooltip": "With this on, your translator will translate Nomai Text instantly."
     },
 
+    "Show Unlock Notification": {
+      "type": "toggle",
+      "value": false,
+      "tooltip": "If enabled, show a text notification at the center of the screen whenever an item is unlocked."
+    },
+
     "Separator - Suit Upgrades": {
       "type": "separator"
     },


### PR DESCRIPTION
This adds NomaiVR compatibility to the mod. 
It also contains #99, an option to show unlocks via prompt messages and a new debug mode (see commit list below).

Most of the commits are somewhat independent, so if any of them should be reworked/removed or moved to a new PR let me know.

# Architecture
All the NomaiVR code is in `ArchipelagoRandomizer.Compatibility.NomaiVR`. VR-fixes are always in that module with hooking points in the main mod code.

# Commit overview

## fix thread-safety when processing AP actions
This is just #99 - I need it because I use the `MainThreadDispatcher` added there for some code.

## vr: fix AP console rendering
This makes sure the AP console is correctly rendered into world space for VR and makes sure it survives camera changes (NomaiVR patches UI things to go into world space but doesn't expect those things to move between cameras [when pausing]). This requires mimicing some things NomaiVR normally does.

## config: add new setting to show unlock notifications
This is unrelated to the main VR compatibility work, it adds a new option to the mod settings (off by default) that shows received items via a center-screen prompt. This is meant to make receiving more obvious / visible without looking at the console. I chose a prompt instead of a notification because that also works outside the suit.
The motivation for this was VR-related though: In VR the console can be hard to read.

Also let me know if I should change the wording here, since unlock is a non-standard term. Could change it to "Received Xyz" instead.

## vr: handle console submit
NomaiVR patches text inputs to make them work in VR using a virtual keyboard. It didn't really work with the AP console input because the AP console input field behaves different than standard Outer Wilds text inputs and also NomaiVR just doesn't add the component required to actually handle submitting the text inside the game world anyway (just in the menus). So the keyboard would just open, you enter your text and nothing happens.

This adds basically a fork of NomaiVRs text input handling with the unique extra of submitting the input field on closing the keyboard.

## fix: harcoded username in csproj
just changed the csproj so it works with the local username

## debug: add flag to only unlock items via !debug
This adds a new compile-time flag that when enabled just fully disables any item-receive logic except for the "!debug" command, making it easier to test locked/unlocked item states.

## vr(tools): fix soft-lock when equipping locked tools suitless
NomaiVR renders the tools as grabable phiysical props in the game world (holsters).

This makes sure that AP's patches for entering the tool mode actually run first (they did for me already, but just making sure) and then adds a Postfix patch to deal with the "invalid" state the NomaiVR holsters are in if the equip was aborted by AP.
(Combined with the next commit this is now just a failsafe, since the next commit should just hide them completely if an item is locked).

## vr(tools): hide NomaiVR holsters for locked tools
This waits for NomaiVR to load its holsters and sets them inactive if the corresponding item is not unlocked. This active state is updated when items are unlocked. This results in you always only having the items in your holsters that you actually own.

It's a bit messy because we have to delay and wait a bit for NomaiVR to have fully loaded all holsters, so there's a "sweeping" logic that retries until they are all there, but it works consistently.

For the split translator there's a new special handling: If any translator is unlocked but you try to grab one you don't have yet, there's a notification that tells you that this translator is not available and you end up not grabbing the tool.

## vr(landing-cam): disable landing cam if not unlocked
Before the landing cam was either always available with NomaiVR or completely broken, depending on which mod's patch ran first.

This again makes sure the patch for the landing cam runs before NomaiVRs patches and then adds a Postfix patch to also properly fix the state again when NomaiVR tried to set up its state and the item is still locked. Result is that you can't enable the landing cam without the item.

## vr(ship-tools): show ship tools as unavailable when locked
NomaiVR adds physical "monitors" to the tools in the ship to interact with them and also changes the landing camera. 

This updates the text on these monitors to show "not available" instead of "interact with screen to activate" when locked. It's a bit hacky, but also set up so that it just fails gracefullly if anything should go wrong.

<img width="1272" height="717" alt="grafik" src="https://github.com/user-attachments/assets/80956d70-b4b9-412d-a18b-be4464f0ebd2" />

## vr(spawn): Suppress NomaiVR spawn rotation patch for non-standard spawn
This disables any rotation/orientation changes NomaiVR tries to apply to the player or Giants Deep when Giants Deep is not where it would be in vanilla.

# AI disclosure
Since I have limited .NET and Unity experience and much less with this mod or NomaiVR. I used Claude Code to troubleshoot most of these issues. A lot of code is generated by it, although in the end I restructured and polished most of it, there's also some I just hand-wrote outright.
All commit messages, this PR description and most in-code comments are either written or rewritten by me.